### PR TITLE
[IMPROVEMENT] AQC111U Driver v1.3.3.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-RPM sources for the aqc111-module package in XCP-ng (https://xcp-ng.org/).
+RPM sources for the aqc111u-module package in XCP-ng (https://xcp-ng.org/).
 
 Make sure to have `git-lfs` installed before cloning. It is used for handling source archives separately.
 

--- a/SOURCES/aqc111u-1.3.3.0.patch
+++ b/SOURCES/aqc111u-1.3.3.0.patch
@@ -1,0 +1,4396 @@
+diff -uNr aqc111u-1.3.3.0/.gitlab-ci.yml aqc111u-1.3.3.0-patch/.gitlab-ci.yml
+--- aqc111u-1.3.3.0/.gitlab-ci.yml	2021-04-04 19:02:03.000000000 -0700
++++ aqc111u-1.3.3.0-patch/.gitlab-ci.yml	2021-04-18 15:50:07.000000000 -0700
+@@ -27,13 +27,13 @@
+   stage: checkpatch
+   <<: *checkpatch-full-only
+   script:
+-    - /usr/src/linux-headers-$(uname -r)/scripts/checkpatch.pl --no-tree -f aqc111.[c,h]
+-    
++    - /usr/src/linux-headers-$(uname -r)/scripts/checkpatch.pl --no-tree -f aqc111u.[c,h]
++
+ checkpatch-soft:
+   stage: checkpatch
+   <<: *checkpatch-soft-only
+   script:
+-    - /usr/src/linux-headers-$(uname -r)/scripts/checkpatch.pl --no-tree --ignore LINUX_VERSION_CODE -f aqc111.[c,h]
++    - /usr/src/linux-headers-$(uname -r)/scripts/checkpatch.pl --no-tree --ignore LINUX_VERSION_CODE -f aqc111u.[c,h]
+ 
+ build-project:
+   stage: build
+diff -uNr aqc111u-1.3.3.0/Makefile aqc111u-1.3.3.0-patch/Makefile
+--- aqc111u-1.3.3.0/Makefile	2021-04-04 19:02:03.000000000 -0700
++++ aqc111u-1.3.3.0-patch/Makefile	2021-04-18 15:49:10.000000000 -0700
+@@ -1,6 +1,6 @@
+ CURRENT	= $(shell uname -r)
+-TARGET	= aqc111
+-OBJS	= aqc111.o
++TARGET	= aqc111u
++OBJS	= aqc111u.o
+ MDIR	= drivers/net/usb
+ 
+ ifndef KDIR
+@@ -20,7 +20,7 @@
+ PWD = $(shell pwd)
+ DEST = /lib/modules/$(CURRENT)/kernel/$(MDIR)
+ 
+-obj-m      :=  $(TARGET).o  
++obj-m      :=  $(TARGET).o
+ 
+ default:
+ 	make -C $(BUILD_DIR) SUBDIRS=$(PWD) modules
+diff -uNr aqc111u-1.3.3.0/README.md aqc111u-1.3.3.0-patch/README.md
+--- aqc111u-1.3.3.0/README.md	2021-04-04 19:02:03.000000000 -0700
++++ aqc111u-1.3.3.0-patch/README.md	2021-04-18 15:49:01.000000000 -0700
+@@ -2,25 +2,25 @@
+ 
+ ## Build from sources:
+ * Unpack sources to temporary folder (e.g `tar -xf pacific.tar.gz`).
+-  It will create Linux/ directory 
++  It will create Linux/ directory
+ * Change directory (`cd Linux`)
+-* Perform `make` 
++* Perform `make`
+ 
+ ## Load driver:
+ * `modprobe usbnet`
+-* `insmod aqc111.ko`
++* `insmod aqc111u.ko`
+ 
+ ## Unload driver:
+-* `rmmod aqc111`
++* `rmmod aqc111u`
+ 
+ ## Install driver:
+ Note: starting from 5.x kernel, driver is built in. Be aware to corrupt original file.
+-* `cp aqc111.ko /lib/modules/$(uname -r)/kernel/drivers/net/usb/`
++* `cp aqc111u.ko /lib/modules/$(uname -r)/kernel/drivers/net/usb/`
+ * `depmod -a`
+ 
+ ## Uninstall driver:
+ Note: starting from 5.x kernel, driver is built in. Be aware to corrupt original file.
+-* `rm /lib/modules/$(uname -r)/kernel/drivers/net/usb/aqc111.ko`
++* `rm /lib/modules/$(uname -r)/kernel/drivers/net/usb/aqc111u.ko`
+ * `depmod -a`
+ 
+ ## Private flags reference:
+diff -uNr aqc111u-1.3.3.0/aqc111.c aqc111u-1.3.3.0-patch/aqc111.c
+--- aqc111u-1.3.3.0/aqc111.c	2021-04-04 19:02:03.000000000 -0700
++++ aqc111u-1.3.3.0-patch/aqc111.c	1969-12-31 16:00:00.000000000 -0800
+@@ -1,1844 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0-or-later
+-/* Aquantia Corp. Aquantia AQtion USB to 5GbE Controller
+- * Copyright (C) 2003-2005 David Hollis <dhollis@davehollis.com>
+- * Copyright (C) 2005 Phil Chang <pchang23@sbcglobal.net>
+- * Copyright (C) 2002-2003 TiVo Inc.
+- * Copyright (C) 2017-2018 ASIX
+- * Copyright (C) 2018 Aquantia Corp.
+- */
+-
+-#include <linux/version.h>
+-#include <linux/module.h>
+-#include <linux/netdevice.h>
+-#include <linux/ethtool.h>
+-#include <linux/mii.h>
+-#include <linux/usb.h>
+-#include <linux/crc32.h>
+-#include <linux/if_vlan.h>
+-#include <linux/usb/cdc.h>
+-#include <linux/workqueue.h>
+-
+-#include "aq_compat.h"
+-#include "aqc111.h"
+-
+-#define DRIVER_VERSION "1.3.3.0"
+-#define DRIVER_NAME "aqc111"
+-
+-static int aqc111_read_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
+-				u16 index, u16 size, void *data)
+-{
+-	int ret;
+-
+-	ret = usbnet_read_cmd_nopm(dev, cmd, USB_DIR_IN | USB_TYPE_VENDOR |
+-				   USB_RECIP_DEVICE, value, index, data, size);
+-
+-	if (unlikely(ret < 0))
+-		netdev_warn(dev->net,
+-			    "Failed to read(0x%x) reg index 0x%04x: %d\n",
+-			    cmd, index, ret);
+-
+-	return ret;
+-}
+-
+-static int aqc111_read_cmd(struct usbnet *dev, u8 cmd, u16 value,
+-			   u16 index, u16 size, void *data)
+-{
+-	int ret;
+-
+-	ret = usbnet_read_cmd(dev, cmd, USB_DIR_IN | USB_TYPE_VENDOR |
+-			      USB_RECIP_DEVICE, value, index, data, size);
+-
+-	if (unlikely(ret < 0))
+-		netdev_warn(dev->net,
+-			    "Failed to read(0x%x) reg index 0x%04x: %d\n",
+-			    cmd, index, ret);
+-
+-	return ret;
+-}
+-
+-static int aqc111_read16_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
+-				  u16 index, u16 *data)
+-{
+-	int ret = 0;
+-
+-	ret = aqc111_read_cmd_nopm(dev, cmd, value, index, sizeof(*data), data);
+-	le16_to_cpus(data);
+-
+-	return ret;
+-}
+-
+-static int aqc111_read16_cmd(struct usbnet *dev, u8 cmd, u16 value,
+-			     u16 index, u16 *data)
+-{
+-	int ret = 0;
+-
+-	ret = aqc111_read_cmd(dev, cmd, value, index, sizeof(*data), data);
+-	le16_to_cpus(data);
+-
+-	return ret;
+-}
+-
+-static int __aqc111_write_cmd(struct usbnet *dev, u8 cmd, u8 reqtype,
+-			      u16 value, u16 index, u16 size, const void *data)
+-{
+-	int err = -ENOMEM;
+-	void *buf = NULL;
+-
+-	netdev_dbg(dev->net,
+-		   "%s cmd=%#x reqtype=%#x value=%#x index=%#x size=%d\n",
+-		   __func__, cmd, reqtype, value, index, size);
+-
+-	if (data) {
+-		buf = kmemdup(data, size, GFP_KERNEL);
+-		if (!buf)
+-			goto out;
+-	}
+-
+-	err = usb_control_msg(dev->udev, usb_sndctrlpipe(dev->udev, 0),
+-			      cmd, reqtype, value, index, buf, size,
+-			      (cmd == AQ_PHY_POWER) ? AQ_USB_PHY_SET_TIMEOUT :
+-			      AQ_USB_SET_TIMEOUT);
+-
+-	if (unlikely(err < 0))
+-		netdev_warn(dev->net,
+-			    "Failed to write(0x%x) reg index 0x%04x: %d\n",
+-			    cmd, index, err);
+-	kfree(buf);
+-
+-out:
+-	return err;
+-}
+-
+-static int aqc111_write_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
+-				 u16 index, u16 size, void *data)
+-{
+-	int ret;
+-
+-	ret = __aqc111_write_cmd(dev, cmd, USB_DIR_OUT | USB_TYPE_VENDOR |
+-				 USB_RECIP_DEVICE, value, index, size, data);
+-
+-	return ret;
+-}
+-
+-static int aqc111_write_cmd(struct usbnet *dev, u8 cmd, u16 value,
+-			    u16 index, u16 size, void *data)
+-{
+-	int ret;
+-
+-	if (usb_autopm_get_interface(dev->intf) < 0)
+-		return -ENODEV;
+-
+-	ret = __aqc111_write_cmd(dev, cmd, USB_DIR_OUT | USB_TYPE_VENDOR |
+-				 USB_RECIP_DEVICE, value, index, size, data);
+-
+-	usb_autopm_put_interface(dev->intf);
+-
+-	return ret;
+-}
+-
+-static int aqc111_write16_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
+-				   u16 index, u16 *data)
+-{
+-	u16 tmp = *data;
+-
+-	cpu_to_le16s(&tmp);
+-
+-	return aqc111_write_cmd_nopm(dev, cmd, value, index, sizeof(tmp), &tmp);
+-}
+-
+-static int aqc111_write16_cmd(struct usbnet *dev, u8 cmd, u16 value,
+-			      u16 index, u16 *data)
+-{
+-	u16 tmp = *data;
+-
+-	cpu_to_le16s(&tmp);
+-
+-	return aqc111_write_cmd(dev, cmd, value, index, sizeof(tmp), &tmp);
+-}
+-
+-static int aqc111_write32_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
+-				   u16 index, u32 *data)
+-{
+-	u32 tmp = *data;
+-
+-	cpu_to_le32s(&tmp);
+-
+-	return aqc111_write_cmd_nopm(dev, cmd, value, index, sizeof(tmp), &tmp);
+-}
+-
+-static int aqc111_write32_cmd(struct usbnet *dev, u8 cmd, u16 value,
+-			      u16 index, u32 *data)
+-{
+-	u32 tmp = *data;
+-
+-	cpu_to_le32s(&tmp);
+-
+-	return aqc111_write_cmd(dev, cmd, value, index, sizeof(tmp), &tmp);
+-}
+-
+-static int aqc111_write_cmd_async(struct usbnet *dev, u8 cmd, u16 value,
+-				  u16 index, u16 size, void *data)
+-{
+-	return usbnet_write_cmd_async(dev, cmd, USB_DIR_OUT | USB_TYPE_VENDOR |
+-				      USB_RECIP_DEVICE, value, index, data,
+-				      size);
+-}
+-
+-static int aqc111_write16_cmd_async(struct usbnet *dev, u8 cmd, u16 value,
+-				    u16 index, u16 *data)
+-{
+-	u16 tmp = *data;
+-
+-	cpu_to_le16s(&tmp);
+-
+-	return aqc111_write_cmd_async(dev, cmd, value, index,
+-				      sizeof(tmp), &tmp);
+-}
+-
+-static int aqc111_mdio_read(struct usbnet *dev, u16 value, u16 index, u16 *data)
+-{
+-	return aqc111_read16_cmd(dev, AQ_PHY_CMD, value, index, data);
+-}
+-
+-static int aqc111_mdio_write(struct usbnet *dev, u16 value,
+-			     u16 index, u16 *data)
+-{
+-	return aqc111_write16_cmd(dev, AQ_PHY_CMD, value, index, data);
+-}
+-
+-#if KERNEL_VERSION(4, 6, 0) > LINUX_VERSION_CODE
+-static int aqc111_get_settings(struct net_device *net, struct ethtool_cmd *cmd)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	struct mii_if_info *mii = &dev->mii;
+-	u32 speed = SPEED_UNKNOWN;
+-
+-	cmd->supported =
+-		(SUPPORTED_100baseT_Full |
+-		 SUPPORTED_1000baseT_Full |
+-		 SUPPORTED_Autoneg | SUPPORTED_TP | SUPPORTED_MII);
+-
+-	/* only supports twisted-pair */
+-	cmd->port = PORT_MII;
+-
+-	/* only supports internal transceiver */
+-	cmd->transceiver = XCVR_INTERNAL;
+-
+-	/* this isn't fully supported at higher layers */
+-	cmd->phy_address = mii->phy_id;
+-	cmd->mdio_support = 0x00; /*Not supported*/
+-
+-	cmd->advertising =
+-		(ADVERTISED_100baseT_Full |
+-		 ADVERTISED_1000baseT_Full |
+-		 ADVERTISED_Autoneg | ADVERTISED_TP | ADVERTISED_MII);
+-
+-	cmd->autoneg = aqc111_data->autoneg;
+-
+-	switch (aqc111_data->link_speed) {
+-	case AQ_INT_SPEED_5G:
+-		speed = SPEED_5000;
+-		break;
+-	case AQ_INT_SPEED_2_5G:
+-		speed = SPEED_2500;
+-		break;
+-	case AQ_INT_SPEED_1G:
+-		speed = SPEED_1000;
+-		break;
+-	case AQ_INT_SPEED_100M:
+-		speed = SPEED_100;
+-		break;
+-	}
+-	cmd->duplex = DUPLEX_FULL;
+-
+-	ethtool_cmd_speed_set(cmd, speed);
+-
+-	mii->full_duplex = cmd->duplex;
+-
+-	return 0;
+-}
+-#endif
+-
+-static void aqc111_get_drvinfo(struct net_device *net,
+-			       struct ethtool_drvinfo *info)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-
+-	/* Inherit standard device info */
+-	usbnet_get_drvinfo(net, info);
+-	strlcpy(info->driver, DRIVER_NAME, sizeof(info->driver));
+-	strlcpy(info->version, DRIVER_VERSION, sizeof(info->version));
+-	snprintf(info->fw_version, sizeof(info->fw_version), "%u.%u.%u",
+-		 aqc111_data->fw_ver.major,
+-		 aqc111_data->fw_ver.minor,
+-		 aqc111_data->fw_ver.rev);
+-	info->eedump_len = 0x00;
+-	info->regdump_len = 0x00;
+-}
+-
+-static void aqc111_get_wol(struct net_device *net,
+-			   struct ethtool_wolinfo *wolinfo)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-
+-	wolinfo->supported = WAKE_MAGIC;
+-	wolinfo->wolopts = 0;
+-
+-	if (aqc111_data->wol_flags & AQ_WOL_FLAG_MP)
+-		wolinfo->wolopts |= WAKE_MAGIC;
+-}
+-
+-static int aqc111_set_wol(struct net_device *net,
+-			  struct ethtool_wolinfo *wolinfo)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-
+-	if (wolinfo->wolopts & ~WAKE_MAGIC)
+-		return -EINVAL;
+-
+-	aqc111_data->wol_flags = 0;
+-	if (wolinfo->wolopts & WAKE_MAGIC)
+-		aqc111_data->wol_flags |= AQ_WOL_FLAG_MP;
+-
+-	return 0;
+-}
+-
+-static const char aqc111_priv_flag_names[][ETH_GSTRING_LEN] = {
+-	"Low Power 5G",
+-	"Thermal throttling",
+-};
+-
+-static void aqc111_get_strings(struct net_device *net, u32 stringset, u8 *data)
+-{
+-	switch (stringset) {
+-	case  ETH_SS_PRIV_FLAGS:
+-		memcpy(data, aqc111_priv_flag_names,
+-		       sizeof(aqc111_priv_flag_names));
+-		break;
+-	}
+-}
+-
+-static u32 aqc111_get_priv_flags(struct net_device *net)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-
+-	return aqc111_data->priv_flags;
+-}
+-
+-static void aqc111_set_phy_speed_fw_iface(struct usbnet *dev,
+-					  struct aqc111_data *aqc111_data)
+-{
+-	aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0, &aqc111_data->phy_cfg);
+-}
+-
+-static void aqc111_set_phy_speed_direct(struct usbnet *dev,
+-					struct aqc111_data *aqc111_data)
+-{
+-	u16 reg16_1 = 0;
+-	u16 reg16_2 = 0;
+-	u16 reg16_3 = 0;
+-
+-	/* Disable auto-negotiation */
+-	reg16_1 = AQ_ANEG_EX_PAGE_CTRL;
+-	aqc111_mdio_write(dev, AQ_AUTONEG_STD_CTRL_REG, AQ_PHY_AUTONEG_ADDR,
+-			  &reg16_1);
+-
+-	reg16_1 = AQ_ANEG_EX_PHY_ID | AQ_ANEG_ADV_AQRATE;
+-	if (aqc111_data->phy_cfg & AQ_DOWNSHIFT) {
+-		reg16_1 |= AQ_ANEG_EN_DSH;
+-		reg16_1 |= (aqc111_data->phy_cfg & AQ_DSH_RETRIES_MASK) >>
+-			    AQ_DSH_RETRIES_SHIFT;
+-	}
+-
+-	reg16_2 = AQ_ANEG_ADV_LT;
+-	if (aqc111_data->phy_cfg & AQ_PAUSE)
+-		reg16_3 |= AQ_ANEG_PAUSE;
+-
+-	if (aqc111_data->phy_cfg & AQ_ASYM_PAUSE)
+-		reg16_3 |= AQ_ANEG_ASYM_PAUSE;
+-
+-	if (aqc111_data->phy_cfg & AQ_ADV_5G) {
+-		reg16_1 |= AQ_ANEG_ADV_5G_N;
+-		reg16_2 |= AQ_ANEG_ADV_5G_T;
+-	}
+-	if (aqc111_data->phy_cfg & AQ_ADV_2G5) {
+-		reg16_1 |= AQ_ANEG_ADV_2G5_N;
+-		reg16_2 |= AQ_ANEG_ADV_2G5_T;
+-	}
+-	if (aqc111_data->phy_cfg & AQ_ADV_1G)
+-		reg16_1 |= AQ_ANEG_ADV_1G;
+-
+-	if (aqc111_data->phy_cfg & AQ_ADV_100M)
+-		reg16_3 |= AQ_ANEG_100M;
+-
+-	aqc111_mdio_write(dev, AQ_AUTONEG_VEN_PROV1_REG,
+-			  AQ_PHY_AUTONEG_ADDR, &reg16_1);
+-	aqc111_mdio_write(dev, AQ_AUTONEG_10GT_CTRL_REG,
+-			  AQ_PHY_AUTONEG_ADDR, &reg16_2);
+-
+-	aqc111_mdio_read(dev, AQ_GLB_SYS_CFG_REG_5G, AQ_PHY_GLOBAL_ADDR,
+-			 &reg16_1);
+-	reg16_1 &= ~AQ_SERDES_MODE_MASK;
+-	if (aqc111_data->phy_cfg & AQ_XFI_DIV_2)
+-		reg16_1 |= AQ_SERDES_MODE_XFI_DIV_2;
+-	else
+-		reg16_1 |= AQ_SERDES_MODE_XFI;
+-
+-	aqc111_mdio_write(dev, AQ_GLB_SYS_CFG_REG_5G, AQ_PHY_GLOBAL_ADDR,
+-			  &reg16_1);
+-
+-	aqc111_mdio_read(dev, AQ_AUTONEG_ADV_REG, AQ_PHY_AUTONEG_ADDR,
+-			 &reg16_1);
+-	reg16_1 &= ~AQ_ANEG_ABILITY_MASK;
+-	reg16_1 |= reg16_3;
+-	aqc111_mdio_write(dev, AQ_AUTONEG_ADV_REG, AQ_PHY_AUTONEG_ADDR,
+-			  &reg16_1);
+-
+-	/* Restart auto-negotiation */
+-	reg16_1 = AQ_ANEG_EX_PAGE_CTRL | AQ_ANEG_EN_ANEG |
+-		  AQ_ANEG_RESTART_ANEG;
+-
+-	aqc111_mdio_write(dev, AQ_AUTONEG_STD_CTRL_REG,
+-			  AQ_PHY_AUTONEG_ADDR, &reg16_1);
+-}
+-
+-static void aqc111_set_phy_speed(struct usbnet *dev, u8 autoneg, u16 speed)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-
+-	aqc111_data->phy_cfg &= ~AQ_ADV_MASK;
+-	aqc111_data->phy_cfg |= AQ_PAUSE;
+-	aqc111_data->phy_cfg |= AQ_ASYM_PAUSE;
+-	aqc111_data->phy_cfg |= AQ_DOWNSHIFT;
+-	aqc111_data->phy_cfg &= ~AQ_DSH_RETRIES_MASK;
+-	aqc111_data->phy_cfg |= (3 << AQ_DSH_RETRIES_SHIFT) &
+-				AQ_DSH_RETRIES_MASK;
+-
+-	aqc111_data->phy_cfg &= ~AQ_XFI_DIV_2;
+-	if (aqc111_data->priv_flags & AQ_PF_XFI_DIV_2)
+-		aqc111_data->phy_cfg |= AQ_XFI_DIV_2;
+-
+-	if (autoneg == AUTONEG_ENABLE) {
+-		switch (speed) {
+-		case SPEED_5000:
+-			aqc111_data->phy_cfg |= AQ_ADV_5G;
+-			/* fall-through */
+-		case SPEED_2500:
+-			aqc111_data->phy_cfg |= AQ_ADV_2G5;
+-			/* fall-through */
+-		case SPEED_1000:
+-			aqc111_data->phy_cfg |= AQ_ADV_1G;
+-			/* fall-through */
+-		case SPEED_100:
+-			aqc111_data->phy_cfg |= AQ_ADV_100M;
+-			/* fall-through */
+-		}
+-	} else {
+-		switch (speed) {
+-		case SPEED_5000:
+-			aqc111_data->phy_cfg |= AQ_ADV_5G;
+-			break;
+-		case SPEED_2500:
+-			aqc111_data->phy_cfg |= AQ_ADV_2G5;
+-			break;
+-		case SPEED_1000:
+-			aqc111_data->phy_cfg |= AQ_ADV_1G;
+-			break;
+-		case SPEED_100:
+-			aqc111_data->phy_cfg |= AQ_ADV_100M;
+-			break;
+-		}
+-	}
+-
+-	if (aqc111_data->dpa)
+-		aqc111_set_phy_speed_direct(dev, aqc111_data);
+-	else
+-		aqc111_set_phy_speed_fw_iface(dev, aqc111_data);
+-}
+-
+-static int aqc111_update_thermal_params(struct usbnet *dev)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	struct aqc111_thermal_params therm_params = {};
+-
+-	therm_params.enable = (aqc111_data->priv_flags & AQ_PF_THERMAL) ? 1 : 0;
+-	therm_params.threshold_critical = AQ_CRITICAL_TEMP_THRESHOLD;
+-	therm_params.threshold_high = AQ_HIGH_TEMP_THRESHOLD;
+-	therm_params.threshold_normal = AQ_NORMAL_TEMP_THRESHOLD;
+-	therm_params.phy_speed_mask = AQ_ADV_100M;
+-	return aqc111_write_cmd(dev, AQ_PHY_THERMAL, 0, 0,
+-				sizeof(struct aqc111_thermal_params),
+-				&therm_params);
+-}
+-
+-static int aqc111_set_priv_flags(struct net_device *net, u32 flags)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u32 changed;
+-
+-	if (flags & ~AQ_PRIV_FLAGS_MASK)
+-		return -EOPNOTSUPP;
+-
+-	changed = aqc111_data->priv_flags^flags;
+-	aqc111_data->priv_flags = flags;
+-
+-	if (!(aqc111_data->phy_cfg & AQ_LOW_POWER) &&
+-	    (aqc111_data->phy_cfg & AQ_PHY_POWER_EN)) {
+-		if (changed & AQ_PF_XFI_DIV_2) {
+-			aqc111_set_phy_speed(dev, aqc111_data->autoneg,
+-					     aqc111_data->advertised_speed);
+-		}
+-	}
+-	if (changed & AQ_PF_THERMAL)
+-		aqc111_update_thermal_params(dev);
+-
+-	return 0;
+-}
+-
+-static int aqc111_get_sset_count(struct net_device *net, int stringset)
+-{
+-	int ret = 0;
+-
+-	switch (stringset) {
+-	case ETH_SS_PRIV_FLAGS:
+-		ret = ARRAY_SIZE(aqc111_priv_flag_names);
+-		break;
+-	default:
+-		ret = -EOPNOTSUPP;
+-	}
+-
+-	return ret;
+-}
+-
+-#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
+-static void aqc111_speed_to_link_mode(u32 speed,
+-				      struct ethtool_link_ksettings *elk)
+-{
+-	switch (speed) {
+-#if KERNEL_VERSION(4, 10, 0) <= LINUX_VERSION_CODE
+-	case SPEED_5000:
+-		ethtool_link_ksettings_add_link_mode(elk, advertising,
+-						     5000baseT_Full);
+-		break;
+-	case SPEED_2500:
+-		ethtool_link_ksettings_add_link_mode(elk, advertising,
+-						     2500baseT_Full);
+-		break;
+-#endif
+-	case SPEED_1000:
+-		ethtool_link_ksettings_add_link_mode(elk, advertising,
+-						     1000baseT_Full);
+-		break;
+-	case SPEED_100:
+-		ethtool_link_ksettings_add_link_mode(elk, advertising,
+-						     100baseT_Full);
+-		break;
+-	}
+-}
+-
+-static int aqc111_get_link_ksettings(struct net_device *net,
+-				     struct ethtool_link_ksettings *elk)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	enum usb_device_speed usb_speed = dev->udev->speed;
+-	u32 speed = SPEED_UNKNOWN;
+-
+-	ethtool_link_ksettings_zero_link_mode(elk, supported);
+-	ethtool_link_ksettings_add_link_mode(elk, supported,
+-					     100baseT_Full);
+-	ethtool_link_ksettings_add_link_mode(elk, supported,
+-					     1000baseT_Full);
+-#if KERNEL_VERSION(4, 10, 0) <= LINUX_VERSION_CODE
+-	if (usb_speed == USB_SPEED_SUPER) {
+-		ethtool_link_ksettings_add_link_mode(elk, supported,
+-						     2500baseT_Full);
+-		ethtool_link_ksettings_add_link_mode(elk, supported,
+-						     5000baseT_Full);
+-	}
+-#endif
+-	ethtool_link_ksettings_add_link_mode(elk, supported, TP);
+-	ethtool_link_ksettings_add_link_mode(elk, supported, Autoneg);
+-
+-	elk->base.port = PORT_TP;
+-#if KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE
+-	elk->base.transceiver = XCVR_INTERNAL;
+-#endif
+-
+-	elk->base.mdio_support = 0x00; /*Not supported*/
+-
+-	if (aqc111_data->autoneg)
+-		linkmode_copy(elk->link_modes.advertising,
+-			      elk->link_modes.supported);
+-	else
+-		aqc111_speed_to_link_mode(aqc111_data->advertised_speed, elk);
+-
+-	elk->base.autoneg = aqc111_data->autoneg;
+-
+-	switch (aqc111_data->link_speed) {
+-	case AQ_INT_SPEED_5G:
+-		speed = SPEED_5000;
+-		break;
+-	case AQ_INT_SPEED_2_5G:
+-		speed = SPEED_2500;
+-		break;
+-	case AQ_INT_SPEED_1G:
+-		speed = SPEED_1000;
+-		break;
+-	case AQ_INT_SPEED_100M:
+-		speed = SPEED_100;
+-		break;
+-	}
+-	elk->base.duplex = DUPLEX_FULL;
+-	elk->base.speed = speed;
+-
+-	return 0;
+-}
+-#endif
+-
+-#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
+-static int aqc111_set_link_ksettings(struct net_device *net,
+-				     const struct ethtool_link_ksettings *elk)
+-#else
+-static int aqc111_set_settings(struct net_device *net, struct ethtool_cmd *cmd)
+-#endif
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	enum usb_device_speed usb_speed = dev->udev->speed;
+-#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
+-	u8 autoneg = elk->base.autoneg;
+-	u32 speed = elk->base.speed;
+-	u8 duplex = elk->base.duplex;
+-#else
+-	u16 speed = ethtool_cmd_speed(cmd);
+-	u8 autoneg = cmd->autoneg;
+-	u8 duplex = cmd->duplex;
+-#endif
+-	if (autoneg == AUTONEG_ENABLE) {
+-		if (aqc111_data->autoneg != AUTONEG_ENABLE) {
+-			aqc111_data->autoneg = AUTONEG_ENABLE;
+-			aqc111_data->advertised_speed =
+-					(usb_speed == USB_SPEED_SUPER) ?
+-					 SPEED_5000 : SPEED_1000;
+-			aqc111_set_phy_speed(dev, aqc111_data->autoneg,
+-					     aqc111_data->advertised_speed);
+-		}
+-	} else {
+-		if (speed != SPEED_100 &&
+-		    speed != SPEED_1000 &&
+-		    speed != SPEED_2500 &&
+-		    speed != SPEED_5000 &&
+-		    speed != SPEED_UNKNOWN)
+-			return -EINVAL;
+-
+-		if (duplex != DUPLEX_FULL)
+-			return -EINVAL;
+-
+-		if (usb_speed != USB_SPEED_SUPER && speed > SPEED_1000)
+-			return -EINVAL;
+-
+-		aqc111_data->autoneg = AUTONEG_DISABLE;
+-		if (speed != SPEED_UNKNOWN)
+-			aqc111_data->advertised_speed = speed;
+-
+-		aqc111_set_phy_speed(dev, aqc111_data->autoneg,
+-				     aqc111_data->advertised_speed);
+-	}
+-
+-	return 0;
+-}
+-
+-static const struct ethtool_ops aqc111_ethtool_ops = {
+-#if KERNEL_VERSION(4, 6, 0) > LINUX_VERSION_CODE
+-	.get_settings = aqc111_get_settings,
+-	.set_settings = aqc111_set_settings,
+-#endif
+-	.get_drvinfo = aqc111_get_drvinfo,
+-	.get_wol = aqc111_get_wol,
+-	.set_wol = aqc111_set_wol,
+-	.get_msglevel = usbnet_get_msglevel,
+-	.set_msglevel = usbnet_set_msglevel,
+-	.get_link = ethtool_op_get_link,
+-	.get_strings = aqc111_get_strings,
+-	.get_priv_flags = aqc111_get_priv_flags,
+-	.set_priv_flags = aqc111_set_priv_flags,
+-	.get_sset_count = aqc111_get_sset_count,
+-#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
+-	.get_link_ksettings = aqc111_get_link_ksettings,
+-	.set_link_ksettings = aqc111_set_link_ksettings
+-#endif
+-};
+-
+-static int aqc111_change_mtu(struct net_device *net, int new_mtu)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	u16 reg16 = 0;
+-	u8 buf[5];
+-
+-#if KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE
+-	if (new_mtu <= 0 || new_mtu > 16334)
+-		return -EINVAL;
+-#endif
+-
+-	net->mtu = new_mtu;
+-	dev->hard_mtu = net->mtu + net->hard_header_len;
+-
+-	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-			  2, &reg16);
+-	if (net->mtu > 1500)
+-		reg16 |= SFR_MEDIUM_JUMBO_EN;
+-	else
+-		reg16 &= ~SFR_MEDIUM_JUMBO_EN;
+-
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-			   2, &reg16);
+-
+-	if (dev->net->mtu > 12500 && dev->net->mtu <= 16334) {
+-		memcpy(buf, &AQC111_BULKIN_SIZE[2], 5);
+-		/* RX bulk configuration */
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QCTRL,
+-				 5, 5, buf);
+-	}
+-
+-	/* Set high low water level */
+-	if (dev->net->mtu <= 4500)
+-		reg16 = 0x0810;
+-	else if (dev->net->mtu <= 9500)
+-		reg16 = 0x1020;
+-	else if (dev->net->mtu <= 12500)
+-		reg16 = 0x1420;
+-	else if (dev->net->mtu <= 16334)
+-		reg16 = 0x1A20;
+-
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_PAUSE_WATERLVL_LOW,
+-			   2, &reg16);
+-
+-	return 0;
+-}
+-
+-static int aqc111_set_mac_addr(struct net_device *net, void *p)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	int ret = 0;
+-
+-	ret = eth_mac_addr(net, p);
+-	if (ret < 0)
+-		return ret;
+-
+-	/* Set the MAC address */
+-	return aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_NODE_ID, ETH_ALEN,
+-				ETH_ALEN, net->dev_addr);
+-}
+-
+-static int aqc111_vlan_rx_kill_vid(struct net_device *net,
+-				   __be16 proto, u16 vid)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	u8 vlan_ctrl = 0;
+-	u16 reg16 = 0;
+-	u8 reg8 = 0;
+-
+-	aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-	vlan_ctrl = reg8;
+-
+-	/* Address */
+-	reg8 = (vid / 16);
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_ADDRESS, 1, 1, &reg8);
+-	/* Data */
+-	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_RD;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
+-	reg16 &= ~(1 << (vid % 16));
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
+-	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_WE;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-
+-	return 0;
+-}
+-
+-static int aqc111_vlan_rx_add_vid(struct net_device *net, __be16 proto, u16 vid)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	u8 vlan_ctrl = 0;
+-	u16 reg16 = 0;
+-	u8 reg8 = 0;
+-
+-	aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-	vlan_ctrl = reg8;
+-
+-	/* Address */
+-	reg8 = (vid / 16);
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_ADDRESS, 1, 1, &reg8);
+-	/* Data */
+-	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_RD;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
+-	reg16 |= (1 << (vid % 16));
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
+-	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_WE;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-
+-	return 0;
+-}
+-
+-static void aqc111_set_rx_mode(struct net_device *net)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	int mc_count = 0;
+-
+-	mc_count = netdev_mc_count(net);
+-
+-	aqc111_data->rxctl &= ~(SFR_RX_CTL_PRO | SFR_RX_CTL_AMALL |
+-				SFR_RX_CTL_AM);
+-
+-	if (net->flags & IFF_PROMISC) {
+-		aqc111_data->rxctl |= SFR_RX_CTL_PRO;
+-	} else if ((net->flags & IFF_ALLMULTI) || mc_count > AQ_MAX_MCAST) {
+-		aqc111_data->rxctl |= SFR_RX_CTL_AMALL;
+-	} else if (!netdev_mc_empty(net)) {
+-		u8 m_filter[AQ_MCAST_FILTER_SIZE] = { 0 };
+-		struct netdev_hw_addr *ha = NULL;
+-		u32 crc_bits = 0;
+-
+-		netdev_for_each_mc_addr(ha, net) {
+-			crc_bits = ether_crc(ETH_ALEN, ha->addr) >> 26;
+-			m_filter[crc_bits >> 3] |= BIT(crc_bits & 7);
+-		}
+-
+-		aqc111_write_cmd_async(dev, AQ_ACCESS_MAC,
+-				       SFR_MULTI_FILTER_ARRY,
+-				       AQ_MCAST_FILTER_SIZE,
+-				       AQ_MCAST_FILTER_SIZE, m_filter);
+-
+-		aqc111_data->rxctl |= SFR_RX_CTL_AM;
+-	}
+-
+-	aqc111_write16_cmd_async(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
+-				 2, &aqc111_data->rxctl);
+-}
+-
+-static int aqc111_set_features(struct net_device *net,
+-			       netdev_features_t features)
+-{
+-	struct usbnet *dev = netdev_priv(net);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	netdev_features_t changed = net->features ^ features;
+-	u16 reg16 = 0;
+-	u8 reg8 = 0;
+-
+-	if (changed & NETIF_F_IP_CSUM) {
+-		aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL, 1, 1, &reg8);
+-		reg8 ^= SFR_TXCOE_TCP | SFR_TXCOE_UDP;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL,
+-				 1, 1, &reg8);
+-	}
+-
+-	if (changed & NETIF_F_IPV6_CSUM) {
+-		aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL, 1, 1, &reg8);
+-		reg8 ^= SFR_TXCOE_TCPV6 | SFR_TXCOE_UDPV6;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL,
+-				 1, 1, &reg8);
+-	}
+-
+-	if (changed & NETIF_F_RXCSUM) {
+-		aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_RXCOE_CTL, 1, 1, &reg8);
+-		if (features & NETIF_F_RXCSUM) {
+-			aqc111_data->rx_checksum = 1;
+-			reg8 &= ~(SFR_RXCOE_IP | SFR_RXCOE_TCP | SFR_RXCOE_UDP |
+-				  SFR_RXCOE_TCPV6 | SFR_RXCOE_UDPV6);
+-		} else {
+-			aqc111_data->rx_checksum = 0;
+-			reg8 |= SFR_RXCOE_IP | SFR_RXCOE_TCP | SFR_RXCOE_UDP |
+-				SFR_RXCOE_TCPV6 | SFR_RXCOE_UDPV6;
+-		}
+-
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RXCOE_CTL,
+-				 1, 1, &reg8);
+-	}
+-	if (changed & NETIF_F_HW_VLAN_CTAG_FILTER) {
+-		if (features & NETIF_F_HW_VLAN_CTAG_FILTER) {
+-			u16 i = 0;
+-
+-			for (i = 0; i < 256; i++) {
+-				/* Address */
+-				reg8 = i;
+-				aqc111_write_cmd(dev, AQ_ACCESS_MAC,
+-						 SFR_VLAN_ID_ADDRESS,
+-						 1, 1, &reg8);
+-				/* Data */
+-				aqc111_write16_cmd(dev, AQ_ACCESS_MAC,
+-						   SFR_VLAN_ID_DATA0,
+-						   2, &reg16);
+-				reg8 = SFR_VLAN_CONTROL_WE;
+-				aqc111_write_cmd(dev, AQ_ACCESS_MAC,
+-						 SFR_VLAN_ID_CONTROL,
+-						 1, 1, &reg8);
+-			}
+-			aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL,
+-					1, 1, &reg8);
+-			reg8 |= SFR_VLAN_CONTROL_VFE;
+-			aqc111_write_cmd(dev, AQ_ACCESS_MAC,
+-					 SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-		} else {
+-			aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL,
+-					1, 1, &reg8);
+-			reg8 &= ~SFR_VLAN_CONTROL_VFE;
+-			aqc111_write_cmd(dev, AQ_ACCESS_MAC,
+-					 SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
+-		}
+-	}
+-
+-	return 0;
+-}
+-
+-static const struct net_device_ops aqc111_netdev_ops = {
+-	.ndo_open		= usbnet_open,
+-	.ndo_stop		= usbnet_stop,
+-	.ndo_start_xmit		= usbnet_start_xmit,
+-	.ndo_tx_timeout		= usbnet_tx_timeout,
+-	.ndo_get_stats64	= usbnet_get_stats64,
+-#if (RHEL_RELEASE_VERSION(7, 5) <= RHEL_RELEASE_CODE)
+-	.extended.ndo_change_mtu = aqc111_change_mtu,
+-	.ndo_size		= sizeof(const struct net_device_ops),
+-#else
+-	.ndo_change_mtu		= aqc111_change_mtu,
+-#endif
+-	.ndo_set_mac_address	= aqc111_set_mac_addr,
+-	.ndo_validate_addr	= eth_validate_addr,
+-	.ndo_vlan_rx_add_vid	= aqc111_vlan_rx_add_vid,
+-	.ndo_vlan_rx_kill_vid	= aqc111_vlan_rx_kill_vid,
+-	.ndo_set_rx_mode	= aqc111_set_rx_mode,
+-	.ndo_set_features	= aqc111_set_features,
+-};
+-
+-static int aqc111_read_perm_mac(struct usbnet *dev)
+-{
+-	u8 buf[ETH_ALEN];
+-	int ret;
+-
+-	ret = aqc111_read_cmd(dev, AQ_FLASH_PARAMETERS, 0, 0, ETH_ALEN, buf);
+-	if (ret < 0)
+-		goto out;
+-
+-	ether_addr_copy(dev->net->perm_addr, buf);
+-
+-	return 0;
+-out:
+-	return ret;
+-}
+-
+-static void aqc111_read_fw_version(struct usbnet *dev,
+-				   struct aqc111_data *aqc111_data)
+-{
+-	aqc111_read_cmd(dev, AQ_ACCESS_MAC, AQ_FW_VER_MAJOR,
+-			1, 1, &aqc111_data->fw_ver.major);
+-	aqc111_read_cmd(dev, AQ_ACCESS_MAC, AQ_FW_VER_MINOR,
+-			1, 1, &aqc111_data->fw_ver.minor);
+-	aqc111_read_cmd(dev, AQ_ACCESS_MAC, AQ_FW_VER_REV,
+-			1, 1, &aqc111_data->fw_ver.rev);
+-
+-	if (aqc111_data->fw_ver.major & 0x80)
+-		aqc111_data->fw_ver.major &= ~0x80;
+-	else
+-		aqc111_data->dpa = 1;
+-}
+-
+-static int aqc111_bind(struct usbnet *dev, struct usb_interface *intf)
+-{
+-	struct usb_device *udev = interface_to_usbdev(intf);
+-	enum usb_device_speed usb_speed = udev->speed;
+-	struct aqc111_data *aqc111_data;
+-	int ret;
+-
+-	/* Force switch to LAN config */
+-	aqc111_write_cmd(dev, AQ_SWITCH_CONFIG, AQ_SW_CONFIG_MAGIC_KEY,
+-			 AQ_SW_CONFIG_LAN, 0, NULL);
+-	/* Check if vendor configuration */
+-	if (udev->actconfig->desc.bConfigurationValue != 1) {
+-		usb_driver_set_configuration(udev, 1);
+-		return -ENODEV;
+-	}
+-
+-	usb_reset_configuration(dev->udev);
+-
+-	ret = usbnet_get_endpoints(dev, intf);
+-	if (ret < 0) {
+-		netdev_dbg(dev->net, "usbnet_get_endpoints failed");
+-		return ret;
+-	}
+-
+-	aqc111_data = kzalloc(sizeof(*aqc111_data), GFP_KERNEL);
+-	if (!aqc111_data)
+-		return -ENOMEM;
+-
+-	/* store aqc111_data pointer in device data field */
+-	dev->driver_priv = aqc111_data;
+-
+-	/* Init the MAC address */
+-	ret = aqc111_read_perm_mac(dev);
+-	if (ret)
+-		goto out;
+-
+-	ether_addr_copy(dev->net->dev_addr, dev->net->perm_addr);
+-
+-	/* Set Rx urb size */
+-	dev->rx_urb_size = URB_SIZE;
+-
+-	/* Set TX needed headroom & tailroom */
+-	dev->net->needed_headroom += sizeof(u64);
+-	dev->net->needed_tailroom += sizeof(u64);
+-
+-#if KERNEL_VERSION(4, 10, 0) <= LINUX_VERSION_CODE
+-	dev->net->max_mtu = 16334;
+-#elif (RHEL_RELEASE_VERSION(7, 5) <= RHEL_RELEASE_CODE)
+-	dev->net->extended->max_mtu = 16334;
+-#endif
+-
+-	dev->net->netdev_ops = &aqc111_netdev_ops;
+-	dev->net->ethtool_ops = &aqc111_ethtool_ops;
+-
+-#if KERNEL_VERSION(3, 12, 0) <= LINUX_VERSION_CODE || (RHEL_RELEASE_CODE)
+-	if (usb_device_no_sg_constraint(dev->udev))
+-		dev->can_dma_sg = 1;
+-#endif
+-
+-	dev->net->hw_features |= AQ_SUPPORT_HW_FEATURE;
+-	dev->net->features |= AQ_SUPPORT_FEATURE;
+-	dev->net->vlan_features |= AQ_SUPPORT_VLAN_FEATURE;
+-
+-	aqc111_read_fw_version(dev, aqc111_data);
+-	aqc111_data->autoneg = AUTONEG_ENABLE;
+-	aqc111_data->advertised_speed = (usb_speed == USB_SPEED_SUPER) ?
+-					 SPEED_5000 : SPEED_1000;
+-	aqc111_data->priv_flags |= AQ_PF_THERMAL;
+-	aqc111_data->rx_checksum = 1;
+-
+-	return 0;
+-
+-out:
+-	kfree(aqc111_data);
+-	return ret;
+-}
+-
+-static void aqc111_unbind(struct usbnet *dev, struct usb_interface *intf)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u16 reg16;
+-	u8 reg8;
+-
+-	/* Force bz */
+-	reg16 = SFR_PHYPWR_RSTCTL_BZ;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
+-				2, &reg16);
+-	reg16 = 0;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
+-				2, &reg16);
+-
+-	/* Power down ethernet PHY */
+-	if (aqc111_data->dpa) {
+-		reg8 = 0x00;
+-		aqc111_write_cmd_nopm(dev, AQ_PHY_POWER, 0,
+-				      0, 1, &reg8);
+-	} else {
+-		aqc111_data->phy_cfg &= ~AQ_ADV_MASK;
+-		aqc111_data->phy_cfg |= AQ_LOW_POWER;
+-		aqc111_data->phy_cfg &= ~AQ_PHY_POWER_EN;
+-		aqc111_write32_cmd_nopm(dev, AQ_PHY_OPS, 0, 0,
+-					&aqc111_data->phy_cfg);
+-	}
+-
+-	kfree(aqc111_data);
+-}
+-
+-static void aqc111_status(struct usbnet *dev, struct urb *urb)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u64 *event_data = NULL;
+-	int link = 0;
+-
+-	if (urb->actual_length < sizeof(*event_data))
+-		return;
+-
+-	event_data = urb->transfer_buffer;
+-	le64_to_cpus(event_data);
+-
+-	if (*event_data & AQ_LS_MASK)
+-		link = 1;
+-	else
+-		link = 0;
+-
+-	aqc111_data->link_speed = (*event_data & AQ_SPEED_MASK) >>
+-				  AQ_SPEED_SHIFT;
+-	aqc111_data->link = link;
+-
+-	if (netif_carrier_ok(dev->net) != link)
+-		usbnet_defer_kevent(dev, EVENT_LINK_RESET);
+-}
+-
+-static void aqc111_configure_rx(struct usbnet *dev,
+-				struct aqc111_data *aqc111_data)
+-{
+-	enum usb_device_speed usb_speed = dev->udev->speed;
+-	u16 link_speed = 0, usb_host = 0;
+-	u8 buf[5] = { 0 };
+-	u8 queue_num = 0;
+-	u16 reg16 = 0;
+-	u8 reg8 = 0;
+-
+-	buf[0] = 0x00;
+-	buf[1] = 0xF8;
+-	buf[2] = 0x07;
+-	switch (aqc111_data->link_speed) {
+-	case AQ_INT_SPEED_5G:
+-		link_speed = 5000;
+-		reg8 = 0x05;
+-		reg16 = 0x001F;
+-		break;
+-	case AQ_INT_SPEED_2_5G:
+-		link_speed = 2500;
+-		reg16 = 0x003F;
+-		break;
+-	case AQ_INT_SPEED_1G:
+-		link_speed = 1000;
+-		reg16 = 0x009F;
+-		break;
+-	case AQ_INT_SPEED_100M:
+-		link_speed = 100;
+-		queue_num = 1;
+-		reg16 = 0x063F;
+-		buf[1] = 0xFB;
+-		buf[2] = 0x4;
+-		break;
+-	}
+-
+-	if (aqc111_data->dpa) {
+-		/* Set Phy Flow control */
+-		aqc111_mdio_write(dev, AQ_GLB_ING_PAUSE_CTRL_REG,
+-				  AQ_PHY_AUTONEG_ADDR, &reg16);
+-		aqc111_mdio_write(dev, AQ_GLB_EGR_PAUSE_CTRL_REG,
+-				  AQ_PHY_AUTONEG_ADDR, &reg16);
+-	}
+-
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_INTER_PACKET_GAP_0,
+-			 1, 1, &reg8);
+-
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TX_PAUSE_RESEND_T, 3, 3, buf);
+-
+-	switch (usb_speed) {
+-	case USB_SPEED_SUPER:
+-		usb_host = 3;
+-		break;
+-	case USB_SPEED_HIGH:
+-		usb_host = 2;
+-		break;
+-	case USB_SPEED_FULL:
+-	case USB_SPEED_LOW:
+-		usb_host = 1;
+-		queue_num = 0;
+-		break;
+-	default:
+-		usb_host = 0;
+-		break;
+-	}
+-
+-	if (dev->net->mtu > 12500 && dev->net->mtu <= 16334)
+-		queue_num = 2; /* For Jumbo packet 16KB */
+-
+-	memcpy(buf, &AQC111_BULKIN_SIZE[queue_num], 5);
+-	/* RX bulk configuration */
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QCTRL, 5, 5, buf);
+-
+-	/* Set high low water level */
+-	if (dev->net->mtu <= 4500)
+-		reg16 = 0x0810;
+-	else if (dev->net->mtu <= 9500)
+-		reg16 = 0x1020;
+-	else if (dev->net->mtu <= 12500)
+-		reg16 = 0x1420;
+-	else if (dev->net->mtu <= 16334)
+-		reg16 = 0x1A20;
+-
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_PAUSE_WATERLVL_LOW,
+-			   2, &reg16);
+-	netdev_info(dev->net, "Link Speed %d, USB %d", link_speed, usb_host);
+-}
+-
+-static void aqc111_configure_csum_offload(struct usbnet *dev)
+-{
+-	u8 reg8 = 0;
+-
+-	if (dev->net->features & NETIF_F_RXCSUM) {
+-		reg8 |= SFR_RXCOE_IP | SFR_RXCOE_TCP | SFR_RXCOE_UDP |
+-			SFR_RXCOE_TCPV6 | SFR_RXCOE_UDPV6;
+-	}
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RXCOE_CTL, 1, 1, &reg8);
+-
+-	reg8 = 0;
+-	if (dev->net->features & NETIF_F_IP_CSUM)
+-		reg8 |= SFR_TXCOE_IP | SFR_TXCOE_TCP | SFR_TXCOE_UDP;
+-
+-	if (dev->net->features & NETIF_F_IPV6_CSUM)
+-		reg8 |= SFR_TXCOE_TCPV6 | SFR_TXCOE_UDPV6;
+-
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL, 1, 1, &reg8);
+-}
+-
+-static int aqc111_link_reset(struct usbnet *dev)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u16 reg16 = 0;
+-	u8 reg8 = 0;
+-
+-	if (aqc111_data->link == 1) { /* Link up */
+-		aqc111_configure_rx(dev, aqc111_data);
+-
+-		/* Vlan Tag Filter */
+-		reg8 = SFR_VLAN_CONTROL_VSO;
+-		if (dev->net->features & NETIF_F_HW_VLAN_CTAG_FILTER)
+-			reg8 |= SFR_VLAN_CONTROL_VFE;
+-
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL,
+-				 1, 1, &reg8);
+-
+-		reg8 = 0x0;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BMRX_DMA_CONTROL,
+-				 1, 1, &reg8);
+-
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BMTX_DMA_CONTROL,
+-				 1, 1, &reg8);
+-
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_ARC_CTRL, 1, 1, &reg8);
+-
+-		reg16 = SFR_RX_CTL_IPE | SFR_RX_CTL_AB;
+-		aqc111_data->rxctl = reg16;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
+-
+-		reg8 = SFR_RX_PATH_READY;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
+-				 1, 1, &reg8);
+-
+-		reg8 = SFR_BULK_OUT_EFF_EN;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
+-				 1, 1, &reg8);
+-
+-		reg16 = 0;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				   2, &reg16);
+-
+-		reg16 = SFR_MEDIUM_XGMIIMODE | SFR_MEDIUM_FULL_DUPLEX;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				   2, &reg16);
+-
+-		aqc111_configure_csum_offload(dev);
+-
+-		aqc111_set_rx_mode(dev->net);
+-
+-		aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				  2, &reg16);
+-
+-		if (dev->net->mtu > 1500)
+-			reg16 |= SFR_MEDIUM_JUMBO_EN;
+-
+-		reg16 |= SFR_MEDIUM_RECEIVE_EN | SFR_MEDIUM_RXFLOW_CTRLEN |
+-			 SFR_MEDIUM_TXFLOW_CTRLEN;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				   2, &reg16);
+-
+-		aqc111_data->rxctl |= SFR_RX_CTL_START;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
+-				   2, &aqc111_data->rxctl);
+-
+-		netif_carrier_on(dev->net);
+-	} else {
+-		aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				  2, &reg16);
+-		reg16 &= ~SFR_MEDIUM_RECEIVE_EN;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				   2, &reg16);
+-
+-		aqc111_data->rxctl &= ~SFR_RX_CTL_START;
+-		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
+-				   2, &aqc111_data->rxctl);
+-
+-		reg8 = SFR_BULK_OUT_FLUSH_EN | SFR_BULK_OUT_EFF_EN;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
+-				 1, 1, &reg8);
+-		reg8 = SFR_BULK_OUT_EFF_EN;
+-		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
+-				 1, 1, &reg8);
+-
+-		netif_carrier_off(dev->net);
+-	}
+-	return 0;
+-}
+-
+-static int aqc111_reset(struct usbnet *dev)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u16 reg16 = 0;
+-	u8 reg8 = 0;
+-
+-	dev->rx_urb_size = URB_SIZE;
+-
+-#if KERNEL_VERSION(3, 12, 0) <= LINUX_VERSION_CODE || (RHEL_RELEASE_CODE)
+-	if (usb_device_no_sg_constraint(dev->udev))
+-		dev->can_dma_sg = 1;
+-#endif
+-
+-	dev->net->hw_features |= AQ_SUPPORT_HW_FEATURE;
+-	dev->net->features |= AQ_SUPPORT_FEATURE;
+-	dev->net->vlan_features |= AQ_SUPPORT_VLAN_FEATURE;
+-
+-	/* Power up ethernet PHY */
+-	aqc111_data->phy_cfg = AQ_PHY_POWER_EN;
+-	if (aqc111_data->dpa) {
+-		aqc111_read_cmd(dev, AQ_PHY_POWER, 0, 0, 1, &reg8);
+-		if (reg8 == 0x00) {
+-			reg8 = 0x02;
+-			aqc111_write_cmd(dev, AQ_PHY_POWER, 0, 0, 1, &reg8);
+-			msleep(200);
+-		}
+-
+-		aqc111_mdio_read(dev, AQ_GLB_STD_CTRL_REG, AQ_PHY_GLOBAL_ADDR,
+-				 &reg16);
+-		if (reg16 & AQ_PHY_LOW_POWER_MODE) {
+-			reg16 &= ~AQ_PHY_LOW_POWER_MODE;
+-			aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG,
+-					  AQ_PHY_GLOBAL_ADDR, &reg16);
+-		}
+-	} else {
+-		aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
+-				   &aqc111_data->phy_cfg);
+-	}
+-
+-	/* Set the MAC address */
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_NODE_ID, ETH_ALEN,
+-			 ETH_ALEN, dev->net->dev_addr);
+-
+-	reg8 = 0xFF;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BM_INT_MASK, 1, 1, &reg8);
+-
+-	reg8 = 0x0;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_SWP_CTRL, 1, 1, &reg8);
+-
+-	aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_MONITOR_MODE, 1, 1, &reg8);
+-	reg8 &= ~(SFR_MONITOR_MODE_EPHYRW | SFR_MONITOR_MODE_RWLC |
+-		  SFR_MONITOR_MODE_RWMP | SFR_MONITOR_MODE_RWWF |
+-		  SFR_MONITOR_MODE_RW_FLAG);
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_MONITOR_MODE, 1, 1, &reg8);
+-
+-	netif_carrier_off(dev->net);
+-
+-	aqc111_update_thermal_params(dev);
+-
+-	/* Phy advertise */
+-	aqc111_set_phy_speed(dev, aqc111_data->autoneg,
+-			     aqc111_data->advertised_speed);
+-
+-	return 0;
+-}
+-
+-static int aqc111_stop(struct usbnet *dev)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u16 reg16 = 0;
+-
+-	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-			  2, &reg16);
+-	reg16 &= ~SFR_MEDIUM_RECEIVE_EN;
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-			   2, &reg16);
+-	reg16 = 0;
+-	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
+-
+-	/* Put PHY to low power*/
+-	if (aqc111_data->dpa) {
+-		reg16 = AQ_PHY_LOW_POWER_MODE;
+-		aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG, AQ_PHY_GLOBAL_ADDR,
+-				  &reg16);
+-	} else {
+-		aqc111_data->phy_cfg |= AQ_LOW_POWER;
+-		aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
+-				   &aqc111_data->phy_cfg);
+-	}
+-
+-	netif_carrier_off(dev->net);
+-
+-	return 0;
+-}
+-
+-static void aqc111_rx_checksum(struct sk_buff *skb, u64 *pkt_desc)
+-{
+-	u32 pkt_type = 0;
+-
+-	skb->ip_summed = CHECKSUM_NONE;
+-	/* checksum error bit is set */
+-	if (*pkt_desc & AQ_RX_PD_L4_ERR || *pkt_desc & AQ_RX_PD_L3_ERR)
+-		return;
+-
+-	pkt_type = *pkt_desc & AQ_RX_PD_L4_TYPE_MASK;
+-	/* It must be a TCP or UDP packet with a valid checksum */
+-	if (pkt_type == AQ_RX_PD_L4_TCP || pkt_type == AQ_RX_PD_L4_UDP)
+-		skb->ip_summed = CHECKSUM_UNNECESSARY;
+-}
+-
+-static int aqc111_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
+-{
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	struct sk_buff *new_skb = NULL;
+-	u32 pkt_total_offset = 0;
+-	u32 start_of_descs = 0;
+-	u64 *pkt_desc = NULL;
+-	u32 desc_offset = 0; /*RX Header Offset*/
+-	u16 pkt_count = 0;
+-	u64 desc_hdr = 0;
+-	u16 vlan_tag = 0;
+-	u32 skb_len = 0;
+-
+-	if (!skb)
+-		goto err;
+-
+-	if (skb->len == 0)
+-		goto err;
+-
+-	skb_len = skb->len;
+-	/* RX Descriptor Header */
+-	skb_trim(skb, skb->len - sizeof(desc_hdr));
+-	desc_hdr = *(u64 *)skb_tail_pointer(skb);
+-	le64_to_cpus(&desc_hdr);
+-
+-	/* Check these packets */
+-	desc_offset = (desc_hdr & AQ_RX_DH_DESC_OFFSET_MASK) >>
+-		      AQ_RX_DH_DESC_OFFSET_SHIFT;
+-	pkt_count = desc_hdr & AQ_RX_DH_PKT_CNT_MASK;
+-	start_of_descs = skb_len - ((pkt_count + 1) *  sizeof(desc_hdr));
+-
+-	/* self check descs position */
+-	if (start_of_descs != desc_offset)
+-		goto err;
+-
+-	/* self check desc_offset from header*/
+-	if (desc_offset >= skb_len)
+-		goto err;
+-
+-	if (pkt_count == 0)
+-		goto err;
+-
+-	/* Get the first RX packet descriptor */
+-	pkt_desc = (u64 *)(skb->data + desc_offset);
+-
+-	while (pkt_count--) {
+-		u32 pkt_len = 0;
+-		u32 pkt_len_with_padd = 0;
+-
+-		le64_to_cpus(pkt_desc);
+-		pkt_len = (u32)((*pkt_desc & AQ_RX_PD_LEN_MASK) >>
+-			  AQ_RX_PD_LEN_SHIFT);
+-		pkt_len_with_padd = ((pkt_len + 7) & 0x7FFF8);
+-
+-		pkt_total_offset += pkt_len_with_padd;
+-		if (pkt_total_offset > desc_offset ||
+-		    (pkt_count == 0 && pkt_total_offset != desc_offset)) {
+-			goto err;
+-		}
+-
+-		if (*pkt_desc & AQ_RX_PD_DROP ||
+-		    !(*pkt_desc & AQ_RX_PD_RX_OK) ||
+-		    pkt_len > (dev->hard_mtu + AQ_RX_HW_PAD))
+-			goto next_desc;
+-
+-		new_skb = netdev_alloc_skb_ip_align(dev->net, pkt_len);
+-
+-		if (!new_skb)
+-			goto err;
+-
+-		skb_put_data(new_skb, skb->data, pkt_len);
+-		skb_pull(new_skb, AQ_RX_HW_PAD);
+-
+-		new_skb->truesize = SKB_TRUESIZE(new_skb->len);
+-		if (aqc111_data->rx_checksum)
+-			aqc111_rx_checksum(new_skb, pkt_desc);
+-
+-		if (*pkt_desc & AQ_RX_PD_VLAN) {
+-			vlan_tag = *pkt_desc >> AQ_RX_PD_VLAN_SHIFT;
+-			__vlan_hwaccel_put_tag(new_skb, htons(ETH_P_8021Q),
+-					       vlan_tag & VLAN_VID_MASK);
+-		}
+-
+-		usbnet_skb_return(dev, new_skb);
+-		if (pkt_count == 0)
+-			break;
+-
+-next_desc:
+-		skb_pull(skb, pkt_len_with_padd);
+-
+-		/* Next RX Packet Descriptor */
+-		pkt_desc++;
+-
+-		new_skb = NULL;
+-	}
+-
+-	return 1;
+-
+-err:
+-	return 0;
+-}
+-
+-static struct sk_buff *aqc111_tx_fixup(struct usbnet *dev, struct sk_buff *skb,
+-				       gfp_t flags)
+-{
+-	int frame_size = dev->maxpacket;
+-	struct sk_buff *new_skb = NULL;
+-	int padding_size = 0;
+-	int headroom = 0;
+-	int tailroom = 0;
+-	u64 tx_desc = 0;
+-	u16 tci = 0;
+-
+-	/*Length of actual data*/
+-	tx_desc |= skb->len & AQ_TX_DESC_LEN_MASK;
+-
+-	/* TSO MSS */
+-	tx_desc |= ((u64)(skb_shinfo(skb)->gso_size & AQ_TX_DESC_MSS_MASK)) <<
+-		   AQ_TX_DESC_MSS_SHIFT;
+-
+-	headroom = (skb->len + sizeof(tx_desc)) % 8;
+-	if (headroom != 0)
+-		padding_size = 8 - headroom;
+-
+-	if (((skb->len + sizeof(tx_desc) + padding_size) % frame_size) == 0) {
+-		padding_size += 8;
+-		tx_desc |= AQ_TX_DESC_DROP_PADD;
+-	}
+-
+-	/* Vlan Tag */
+-	if (vlan_get_tag(skb, &tci) >= 0) {
+-		tx_desc |= AQ_TX_DESC_VLAN;
+-		tx_desc |= ((u64)tci & AQ_TX_DESC_VLAN_MASK) <<
+-			   AQ_TX_DESC_VLAN_SHIFT;
+-	}
+-
+-	if (
+-#if KERNEL_VERSION(3, 12, 0) <= LINUX_VERSION_CODE || (RHEL_RELEASE_CODE)
+-	    !dev->can_dma_sg &&
+-#endif
+-	    (dev->net->features & NETIF_F_SG) &&
+-	    skb_linearize(skb))
+-		return NULL;
+-
+-	headroom = skb_headroom(skb);
+-	tailroom = skb_tailroom(skb);
+-
+-	if (!(headroom >= sizeof(tx_desc) && tailroom >= padding_size)) {
+-		new_skb = skb_copy_expand(skb, sizeof(tx_desc),
+-					  padding_size, flags);
+-		dev_kfree_skb_any(skb);
+-		skb = new_skb;
+-		if (!skb)
+-			return NULL;
+-	}
+-	if (padding_size != 0)
+-		skb_put(skb, padding_size);
+-	/* Copy TX header */
+-	skb_push(skb, sizeof(tx_desc));
+-	cpu_to_le64s(&tx_desc);
+-	skb_copy_to_linear_data(skb, &tx_desc, sizeof(tx_desc));
+-
+-	usbnet_set_skb_tx_stats(skb, 1, 0);
+-
+-	return skb;
+-}
+-
+-static const struct driver_info aqc111_info = {
+-	.description	= "Aquantia AQtion USB to 5GbE Controller",
+-	.bind		= aqc111_bind,
+-	.unbind		= aqc111_unbind,
+-	.status		= aqc111_status,
+-	.link_reset	= aqc111_link_reset,
+-	.reset		= aqc111_reset,
+-	.stop		= aqc111_stop,
+-	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
+-			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
+-	.rx_fixup	= aqc111_rx_fixup,
+-	.tx_fixup	= aqc111_tx_fixup,
+-};
+-
+-#define ASIX111_DESC \
+-"ASIX USB 3.1 Gen1 to 5G Multi-Gigabit Ethernet Adapter"
+-
+-static const struct driver_info asix111_info = {
+-	.description	= ASIX111_DESC,
+-	.bind		= aqc111_bind,
+-	.unbind		= aqc111_unbind,
+-	.status		= aqc111_status,
+-	.link_reset	= aqc111_link_reset,
+-	.reset		= aqc111_reset,
+-	.stop		= aqc111_stop,
+-	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
+-			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
+-	.rx_fixup	= aqc111_rx_fixup,
+-	.tx_fixup	= aqc111_tx_fixup,
+-};
+-
+-#undef ASIX111_DESC
+-
+-#define ASIX112_DESC \
+-"ASIX USB 3.1 Gen1 to 2.5G Multi-Gigabit Ethernet Adapter"
+-
+-static const struct driver_info asix112_info = {
+-	.description	= ASIX112_DESC,
+-	.bind		= aqc111_bind,
+-	.unbind		= aqc111_unbind,
+-	.status		= aqc111_status,
+-	.link_reset	= aqc111_link_reset,
+-	.reset		= aqc111_reset,
+-	.stop		= aqc111_stop,
+-	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
+-			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
+-	.rx_fixup	= aqc111_rx_fixup,
+-	.tx_fixup	= aqc111_tx_fixup,
+-};
+-
+-#undef ASIX112_DESC
+-
+-static const struct driver_info trendnet_info = {
+-	.description	= "USB-C 3.1 to 5GBASE-T Ethernet Adapter",
+-	.bind		= aqc111_bind,
+-	.unbind		= aqc111_unbind,
+-	.status		= aqc111_status,
+-	.link_reset	= aqc111_link_reset,
+-	.reset		= aqc111_reset,
+-	.stop		= aqc111_stop,
+-	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
+-			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
+-	.rx_fixup	= aqc111_rx_fixup,
+-	.tx_fixup	= aqc111_tx_fixup,
+-};
+-
+-static const struct driver_info qnap_info = {
+-	.description	= "QNAP QNA-UC5G1T USB to 5GbE Adapter",
+-	.bind		= aqc111_bind,
+-	.unbind		= aqc111_unbind,
+-	.status		= aqc111_status,
+-	.link_reset	= aqc111_link_reset,
+-	.reset		= aqc111_reset,
+-	.stop		= aqc111_stop,
+-	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
+-			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
+-	.rx_fixup	= aqc111_rx_fixup,
+-	.tx_fixup	= aqc111_tx_fixup,
+-};
+-
+-static int aqc111_suspend(struct usb_interface *intf, pm_message_t message)
+-{
+-	struct usbnet *dev = usb_get_intfdata(intf);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u16 temp_rx_ctrl = 0x00;
+-	u16 reg16;
+-	u8 reg8;
+-
+-	usbnet_suspend(intf, message);
+-
+-	aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
+-	temp_rx_ctrl = reg16;
+-	/* Stop RX operations*/
+-	reg16 &= ~SFR_RX_CTL_START;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
+-	/* Force bz */
+-	aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
+-			       2, &reg16);
+-	reg16 |= SFR_PHYPWR_RSTCTL_BZ;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
+-				2, &reg16);
+-
+-	reg8 = SFR_BULK_OUT_EFF_EN;
+-	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
+-			      1, 1, &reg8);
+-
+-	temp_rx_ctrl &= ~(SFR_RX_CTL_START | SFR_RX_CTL_RF_WAK |
+-			  SFR_RX_CTL_AP | SFR_RX_CTL_AM);
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
+-				2, &temp_rx_ctrl);
+-
+-	reg8 = 0x00;
+-	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
+-			      1, 1, &reg8);
+-
+-	if (aqc111_data->wol_flags) {
+-		struct aqc111_wol_cfg wol_cfg = { 0 };
+-
+-		aqc111_data->phy_cfg |= AQ_WOL;
+-		if (aqc111_data->dpa) {
+-			reg8 = 0;
+-			if (aqc111_data->wol_flags & AQ_WOL_FLAG_MP)
+-				reg8 |= SFR_MONITOR_MODE_RWMP;
+-			aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC,
+-					      SFR_MONITOR_MODE, 1, 1, &reg8);
+-		} else {
+-			ether_addr_copy(wol_cfg.hw_addr, dev->net->dev_addr);
+-			wol_cfg.flags = aqc111_data->wol_flags;
+-		}
+-
+-		temp_rx_ctrl |= (SFR_RX_CTL_AB | SFR_RX_CTL_START);
+-		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
+-					2, &temp_rx_ctrl);
+-		reg8 = 0x00;
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BM_INT_MASK,
+-				      1, 1, &reg8);
+-		reg8 = SFR_BMRX_DMA_EN;
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BMRX_DMA_CONTROL,
+-				      1, 1, &reg8);
+-		reg8 = SFR_RX_PATH_READY;
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
+-				      1, 1, &reg8);
+-		reg8 = 0x07;
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QCTRL,
+-				      1, 1, &reg8);
+-		reg8 = 0x00;
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC,
+-				      SFR_RX_BULKIN_QTIMR_LOW, 1, 1, &reg8);
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC,
+-				      SFR_RX_BULKIN_QTIMR_HIGH, 1, 1, &reg8);
+-		reg8 = 0xFF;
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QSIZE,
+-				      1, 1, &reg8);
+-		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QIFG,
+-				      1, 1, &reg8);
+-
+-		aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC,
+-				       SFR_MEDIUM_STATUS_MODE, 2, &reg16);
+-		reg16 |= SFR_MEDIUM_RECEIVE_EN;
+-		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC,
+-					SFR_MEDIUM_STATUS_MODE, 2, &reg16);
+-
+-		if (aqc111_data->dpa) {
+-			aqc111_set_phy_speed(dev, AUTONEG_ENABLE, SPEED_100);
+-		} else {
+-			aqc111_write_cmd(dev, AQ_WOL_CFG, 0, 0,
+-					 WOL_CFG_SIZE, &wol_cfg);
+-			aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
+-					   &aqc111_data->phy_cfg);
+-		}
+-	} else {
+-		aqc111_data->phy_cfg |= AQ_LOW_POWER;
+-		if (!aqc111_data->dpa) {
+-			aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
+-					   &aqc111_data->phy_cfg);
+-		} else {
+-			reg16 = AQ_PHY_LOW_POWER_MODE;
+-			aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG,
+-					  AQ_PHY_GLOBAL_ADDR, &reg16);
+-		}
+-
+-		/* Disable RX path */
+-		aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC,
+-				       SFR_MEDIUM_STATUS_MODE, 2, &reg16);
+-		reg16 &= ~SFR_MEDIUM_RECEIVE_EN;
+-		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC,
+-					SFR_MEDIUM_STATUS_MODE, 2, &reg16);
+-	}
+-
+-	return 0;
+-}
+-
+-static int aqc111_resume(struct usb_interface *intf)
+-{
+-	struct usbnet *dev = usb_get_intfdata(intf);
+-	struct aqc111_data *aqc111_data = dev->driver_priv;
+-	u16 reg16;
+-	u8 reg8;
+-
+-	netif_carrier_off(dev->net);
+-
+-	/* Power up ethernet PHY */
+-	aqc111_data->phy_cfg |= AQ_PHY_POWER_EN;
+-	aqc111_data->phy_cfg &= ~AQ_LOW_POWER;
+-	aqc111_data->phy_cfg &= ~AQ_WOL;
+-	if (aqc111_data->dpa) {
+-		aqc111_read_cmd_nopm(dev, AQ_PHY_POWER, 0, 0, 1, &reg8);
+-		if (reg8 == 0x00) {
+-			reg8 = 0x02;
+-			aqc111_write_cmd_nopm(dev, AQ_PHY_POWER, 0, 0,
+-					      1, &reg8);
+-			msleep(200);
+-		}
+-
+-		aqc111_mdio_read(dev, AQ_GLB_STD_CTRL_REG, AQ_PHY_GLOBAL_ADDR,
+-				 &reg16);
+-		if (reg16 & AQ_PHY_LOW_POWER_MODE) {
+-			reg16 &= ~AQ_PHY_LOW_POWER_MODE;
+-			aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG,
+-					  AQ_PHY_GLOBAL_ADDR, &reg16);
+-		}
+-	}
+-
+-	reg8 = 0xFF;
+-	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BM_INT_MASK,
+-			      1, 1, &reg8);
+-	/* Configure RX control register => start operation */
+-	reg16 = aqc111_data->rxctl;
+-	reg16 &= ~SFR_RX_CTL_START;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
+-
+-	reg16 |= SFR_RX_CTL_START;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
+-
+-	aqc111_set_phy_speed(dev, aqc111_data->autoneg,
+-			     aqc111_data->advertised_speed);
+-
+-	aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-			       2, &reg16);
+-	reg16 |= SFR_MEDIUM_RECEIVE_EN;
+-	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
+-				2, &reg16);
+-	reg8 = SFR_RX_PATH_READY;
+-	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
+-			      1, 1, &reg8);
+-	reg8 = 0x0;
+-	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BMRX_DMA_CONTROL, 1, 1, &reg8);
+-
+-	return usbnet_resume(intf);
+-}
+-
+-#define AQC111_USB_ETH_DEV(vid, pid, table) \
+-	USB_DEVICE_INTERFACE_CLASS((vid), (pid), USB_CLASS_VENDOR_SPEC), \
+-	.driver_info = (unsigned long)&(table) \
+-}, \
+-{ \
+-	USB_DEVICE_AND_INTERFACE_INFO((vid), (pid), \
+-				      USB_CLASS_COMM, \
+-				      USB_CDC_SUBCLASS_ETHERNET, \
+-				      USB_CDC_PROTO_NONE), \
+-	.driver_info = (unsigned long)&(table),
+-
+-static const struct usb_device_id products[] = {
+-	{AQC111_USB_ETH_DEV(0x2eca, 0xc101, aqc111_info)},
+-	{AQC111_USB_ETH_DEV(0x0b95, 0x2790, asix111_info)},
+-	{AQC111_USB_ETH_DEV(0x0b95, 0x2791, asix112_info)},
+-	{AQC111_USB_ETH_DEV(0x20f4, 0xe05a, trendnet_info)},
+-	{AQC111_USB_ETH_DEV(0x1c04, 0x0015, qnap_info)},
+-	{ },/* END */
+-};
+-MODULE_DEVICE_TABLE(usb, products);
+-
+-static struct usb_driver aq_driver = {
+-	.name		= "aqc111",
+-	.id_table	= products,
+-	.probe		= usbnet_probe,
+-	.suspend	= aqc111_suspend,
+-	.resume		= aqc111_resume,
+-	.disconnect	= usbnet_disconnect,
+-};
+-
+-module_usb_driver(aq_driver);
+-
+-MODULE_DESCRIPTION("Aquantia AQtion USB to 5/2.5GbE Controllers");
+-MODULE_LICENSE("GPL");
+diff -uNr aqc111u-1.3.3.0/aqc111.h aqc111u-1.3.3.0-patch/aqc111.h
+--- aqc111u-1.3.3.0/aqc111.h	2021-04-04 19:02:03.000000000 -0700
++++ aqc111u-1.3.3.0-patch/aqc111.h	1969-12-31 16:00:00.000000000 -0800
+@@ -1,308 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0-or-later
+- * Aquantia Corp. Aquantia AQtion USB to 5GbE Controller
+- * Copyright (C) 2003-2005 David Hollis <dhollis@davehollis.com>
+- * Copyright (C) 2005 Phil Chang <pchang23@sbcglobal.net>
+- * Copyright (C) 2002-2003 TiVo Inc.
+- * Copyright (C) 2017-2018 ASIX
+- * Copyright (C) 2018 Aquantia Corp.
+- */
+-
+-#ifndef __LINUX_USBNET_AQC111_H
+-#define __LINUX_USBNET_AQC111_H
+-
+-#define URB_SIZE	(1024 * 62)
+-
+-#define AQ_MCAST_FILTER_SIZE		8
+-#define AQ_MAX_MCAST			64
+-
+-#define AQ_ACCESS_MAC			0x01
+-#define AQ_FLASH_PARAMETERS		0x20
+-#define AQ_PHY_POWER			0x31
+-#define AQ_PHY_CMD			0x32
+-#define AQ_WOL_CFG			0x60
+-#define AQ_PHY_OPS			0x61
+-#define AQ_PHY_THERMAL			0x64
+-#define AQ_USBDC_CMD			0x81
+-#define AQ_SWITCH_CONFIG		0xB0
+-
+-#define AQC111_PHY_ID			0x00
+-#define AQ_PHY_ADDR(mmd)		((AQC111_PHY_ID << 8) | mmd)
+-
+-#define AQ_PHY_AUTONEG_MMD		0x07
+-#define AQ_PHY_AUTONEG_ADDR		AQ_PHY_ADDR(AQ_PHY_AUTONEG_MMD)
+-
+-#define AQ_AUTONEG_STD_CTRL_REG		0x0000
+-	#define AQ_ANEG_EX_PAGE_CTRL		0x2000
+-	#define AQ_ANEG_EN_ANEG			0x1000
+-	#define AQ_ANEG_RESTART_ANEG		0x0200
+-
+-#define AQ_AUTONEG_ADV_REG		0x0010
+-	#define AQ_ANEG_100M			0x0100
+-	#define AQ_ANEG_PAUSE			0x0400
+-	#define AQ_ANEG_ASYM_PAUSE		0x0800
+-	#define AQ_ANEG_ABILITY_MASK		0x0FE0
+-
+-#define AQ_AUTONEG_10GT_CTRL_REG	0x0020
+-	#define AQ_ANEG_ADV_10G_T		0x1000
+-	#define AQ_ANEG_ADV_5G_T		0x0100
+-	#define AQ_ANEG_ADV_2G5_T		0x0080
+-	#define AQ_ANEG_ADV_LT			0x0001
+-
+-#define AQ_AUTONEG_VEN_PROV1_REG	0xC400
+-	#define AQ_ANEG_ADV_1G			0x8000
+-	#define AQ_ANEG_ADV_AQRATE		0x1000
+-	#define AQ_ANEG_ADV_5G_N		0x0800
+-	#define AQ_ANEG_ADV_2G5_N		0x0400
+-	#define AQ_ANEG_EX_PHY_ID		0x0040
+-	#define AQ_ANEG_EN_DSH			0x0010
+-	#define AQ_ANEG_DSH_RETRY		0x0003
+-
+-#define AQ_PHY_GLOBAL_MMD		0x1E
+-#define AQ_PHY_GLOBAL_ADDR		AQ_PHY_ADDR(AQ_PHY_GLOBAL_MMD)
+-
+-#define AQ_GLB_STD_CTRL_REG		0x0000
+-	#define AQ_PHY_LOW_POWER_MODE		0x0800
+-
+-#define AQ_GLB_SYS_CFG_REG_5G		0x031E
+-	#define AQ_SERDES_MODE_MASK		0x0007
+-	#define AQ_SERDES_MODE_XFI_DIV_2	0x0006
+-	#define AQ_SERDES_MODE_XFI		0x0000
+-
+-#define AQ_GLB_ING_PAUSE_CTRL_REG	0x7148
+-#define AQ_GLB_EGR_PAUSE_CTRL_REG	0x4148
+-
+-#define AQ_USB_PHY_SET_TIMEOUT		10000
+-#define AQ_USB_SET_TIMEOUT		4000
+-
+-#define AQ_THERMAL_TIMER_MS		500
+-/* Temperature thresholds in units degree of Celsius */
+-#define AQ_NORMAL_TEMP_THRESHOLD	85
+-#define AQ_HIGH_TEMP_THRESHOLD		106
+-#define AQ_CRITICAL_TEMP_THRESHOLD	108
+-
+-#define AQ_SW_CONFIG_MAGIC_KEY		0xABBA
+-#define AQ_SW_CONFIG_LAN		0x0001
+-/* Feature. ********************************************/
+-#define AQ_SUPPORT_FEATURE	(NETIF_F_SG | NETIF_F_IP_CSUM |\
+-				 NETIF_F_IPV6_CSUM | NETIF_F_RXCSUM |\
+-				 NETIF_F_TSO | NETIF_F_HW_VLAN_CTAG_TX |\
+-				 NETIF_F_HW_VLAN_CTAG_RX)
+-
+-#define AQ_SUPPORT_HW_FEATURE	(NETIF_F_SG | NETIF_F_IP_CSUM |\
+-				 NETIF_F_IPV6_CSUM | NETIF_F_RXCSUM |\
+-				 NETIF_F_TSO | NETIF_F_HW_VLAN_CTAG_FILTER)
+-
+-#define AQ_SUPPORT_VLAN_FEATURE (NETIF_F_SG | NETIF_F_IP_CSUM |\
+-				 NETIF_F_IPV6_CSUM | NETIF_F_RXCSUM |\
+-				 NETIF_F_TSO)
+-
+-/* DC Reg. *********************************************/
+-#define DC_SS_CTL			0x310
+-
+-/* SFR Reg. ********************************************/
+-
+-#define SFR_GENERAL_STATUS		0x03
+-#define SFR_CHIP_STATUS			0x05
+-#define SFR_RX_CTL			0x0B
+-	#define SFR_RX_CTL_TXPADCRC		0x0400
+-	#define SFR_RX_CTL_IPE			0x0200
+-	#define SFR_RX_CTL_DROPCRCERR		0x0100
+-	#define SFR_RX_CTL_START		0x0080
+-	#define SFR_RX_CTL_RF_WAK		0x0040
+-	#define SFR_RX_CTL_AP			0x0020
+-	#define SFR_RX_CTL_AM			0x0010
+-	#define SFR_RX_CTL_AB			0x0008
+-	#define SFR_RX_CTL_AMALL		0x0002
+-	#define SFR_RX_CTL_PRO			0x0001
+-	#define SFR_RX_CTL_STOP			0x0000
+-#define SFR_INTER_PACKET_GAP_0		0x0D
+-#define SFR_NODE_ID			0x10
+-#define SFR_MULTI_FILTER_ARRY		0x16
+-#define SFR_MEDIUM_STATUS_MODE		0x22
+-	#define SFR_MEDIUM_XGMIIMODE		0x0001
+-	#define SFR_MEDIUM_FULL_DUPLEX		0x0002
+-	#define SFR_MEDIUM_RXFLOW_CTRLEN	0x0010
+-	#define SFR_MEDIUM_TXFLOW_CTRLEN	0x0020
+-	#define SFR_MEDIUM_JUMBO_EN		0x0040
+-	#define SFR_MEDIUM_RECEIVE_EN		0x0100
+-#define SFR_MONITOR_MODE		0x24
+-	#define SFR_MONITOR_MODE_EPHYRW		0x01
+-	#define SFR_MONITOR_MODE_RWLC		0x02
+-	#define SFR_MONITOR_MODE_RWMP		0x04
+-	#define SFR_MONITOR_MODE_RWWF		0x08
+-	#define SFR_MONITOR_MODE_RW_FLAG	0x10
+-	#define SFR_MONITOR_MODE_PMEPOL		0x20
+-	#define SFR_MONITOR_MODE_PMETYPE	0x40
+-#define SFR_PHYPWR_RSTCTL		0x26
+-	#define SFR_PHYPWR_RSTCTL_BZ		0x0010
+-	#define SFR_PHYPWR_RSTCTL_IPRL		0x0020
+-#define SFR_VLAN_ID_ADDRESS		0x2A
+-#define SFR_VLAN_ID_CONTROL		0x2B
+-	#define SFR_VLAN_CONTROL_WE		0x0001
+-	#define SFR_VLAN_CONTROL_RD		0x0002
+-	#define SFR_VLAN_CONTROL_VSO		0x0010
+-	#define SFR_VLAN_CONTROL_VFE		0x0020
+-#define SFR_VLAN_ID_DATA0		0x2C
+-#define SFR_VLAN_ID_DATA1		0x2D
+-#define SFR_RX_BULKIN_QCTRL		0x2E
+-	#define SFR_RX_BULKIN_QCTRL_TIME	0x01
+-	#define SFR_RX_BULKIN_QCTRL_IFG		0x02
+-	#define SFR_RX_BULKIN_QCTRL_SIZE	0x04
+-#define SFR_RX_BULKIN_QTIMR_LOW		0x2F
+-#define SFR_RX_BULKIN_QTIMR_HIGH	0x30
+-#define SFR_RX_BULKIN_QSIZE		0x31
+-#define SFR_RX_BULKIN_QIFG		0x32
+-#define SFR_RXCOE_CTL			0x34
+-	#define SFR_RXCOE_IP			0x01
+-	#define SFR_RXCOE_TCP			0x02
+-	#define SFR_RXCOE_UDP			0x04
+-	#define SFR_RXCOE_ICMP			0x08
+-	#define SFR_RXCOE_IGMP			0x10
+-	#define SFR_RXCOE_TCPV6			0x20
+-	#define SFR_RXCOE_UDPV6			0x40
+-	#define SFR_RXCOE_ICMV6			0x80
+-#define SFR_TXCOE_CTL			0x35
+-	#define SFR_TXCOE_IP			0x01
+-	#define SFR_TXCOE_TCP			0x02
+-	#define SFR_TXCOE_UDP			0x04
+-	#define SFR_TXCOE_ICMP			0x08
+-	#define SFR_TXCOE_IGMP			0x10
+-	#define SFR_TXCOE_TCPV6			0x20
+-	#define SFR_TXCOE_UDPV6			0x40
+-	#define SFR_TXCOE_ICMV6			0x80
+-#define SFR_BM_INT_MASK			0x41
+-#define SFR_BMRX_DMA_CONTROL		0x43
+-	#define SFR_BMRX_DMA_EN			0x80
+-#define SFR_BMTX_DMA_CONTROL		0x46
+-#define SFR_PAUSE_WATERLVL_LOW		0x54
+-#define SFR_PAUSE_WATERLVL_HIGH		0x55
+-#define SFR_ARC_CTRL			0x9E
+-#define SFR_SWP_CTRL			0xB1
+-#define SFR_TX_PAUSE_RESEND_T		0xB2
+-#define SFR_ETH_MAC_PATH		0xB7
+-	#define SFR_RX_PATH_READY		0x01
+-#define SFR_BULK_OUT_CTRL		0xB9
+-	#define SFR_BULK_OUT_FLUSH_EN		0x01
+-	#define SFR_BULK_OUT_EFF_EN		0x02
+-
+-#define AQ_FW_VER_MAJOR			0xDA
+-#define AQ_FW_VER_MINOR			0xDB
+-#define AQ_FW_VER_REV			0xDC
+-
+-#define AQ_PRIV_FLAGS_MASK		0x3
+-#define AQ_PF_XFI_DIV_2			BIT(0)
+-#define AQ_PF_THERMAL			BIT(1)
+-
+-/*PHY_OPS**********************************************************************/
+-
+-#define AQ_ADV_100M	BIT(0)
+-#define AQ_ADV_1G	BIT(1)
+-#define AQ_ADV_2G5	BIT(2)
+-#define AQ_ADV_5G	BIT(3)
+-#define AQ_ADV_MASK	0x0F
+-
+-#define AQ_PAUSE	BIT(16)
+-#define AQ_ASYM_PAUSE	BIT(17)
+-#define AQ_LOW_POWER	BIT(18)
+-#define AQ_PHY_POWER_EN	BIT(19)
+-#define AQ_WOL		BIT(20)
+-#define AQ_DOWNSHIFT	BIT(21)
+-#define AQ_XFI_DIV_2	BIT(22)
+-
+-#define AQ_DSH_RETRIES_SHIFT	0x18
+-#define AQ_DSH_RETRIES_MASK	0xF000000
+-
+-#define AQ_WOL_FLAG_MP			0x2
+-
+-/******************************************************************************/
+-
+-struct aqc111_wol_cfg {
+-	u8 hw_addr[6];
+-	u8 flags;
+-	u8 rsvd[283];
+-} __packed;
+-
+-struct aqc111_thermal_params {
+-	u8 enable;
+-	u8 threshold_critical;
+-	u8 threshold_high;
+-	u8 threshold_normal;
+-	u8 phy_speed_mask;
+-} __packed;
+-
+-#define WOL_CFG_SIZE sizeof(struct aqc111_wol_cfg)
+-
+-struct aqc111_data {
+-	u16 rxctl;
+-	u8 rx_checksum;
+-	u8 link_speed;
+-	u8 link;
+-	u8 autoneg;
+-	u32 advertised_speed;
+-	struct {
+-		u8 major;
+-		u8 minor;
+-		u8 rev;
+-	} fw_ver;
+-	u8 dpa; /*direct PHY access*/
+-	u32 phy_cfg;
+-	u8 wol_flags;
+-	u32 priv_flags;
+-};
+-
+-#define AQ_LS_MASK		0x8000
+-#define AQ_SPEED_MASK		0x7F00
+-#define AQ_SPEED_SHIFT		0x0008
+-#define AQ_INT_SPEED_5G		0x000F
+-#define AQ_INT_SPEED_2_5G	0x0010
+-#define AQ_INT_SPEED_1G		0x0011
+-#define AQ_INT_SPEED_100M	0x0013
+-
+-/* TX Descriptor */
+-#define AQ_TX_DESC_LEN_MASK	0x1FFFFF
+-#define AQ_TX_DESC_DROP_PADD	BIT(28)
+-#define AQ_TX_DESC_VLAN		BIT(29)
+-#define AQ_TX_DESC_MSS_MASK	0x7FFF
+-#define AQ_TX_DESC_MSS_SHIFT	0x20
+-#define AQ_TX_DESC_VLAN_MASK	0xFFFF
+-#define AQ_TX_DESC_VLAN_SHIFT	0x30
+-
+-#define AQ_RX_HW_PAD			0x02
+-
+-/* RX Packet Descriptor */
+-#define AQ_RX_PD_L4_ERR		BIT(0)
+-#define AQ_RX_PD_L3_ERR		BIT(1)
+-#define AQ_RX_PD_L4_TYPE_MASK	0x1C
+-#define AQ_RX_PD_L4_UDP		0x04
+-#define AQ_RX_PD_L4_TCP		0x10
+-#define AQ_RX_PD_L3_TYPE_MASK	0x60
+-#define AQ_RX_PD_L3_IP		0x20
+-#define AQ_RX_PD_L3_IP6		0x40
+-
+-#define AQ_RX_PD_VLAN		BIT(10)
+-#define AQ_RX_PD_RX_OK		BIT(11)
+-#define AQ_RX_PD_DROP		BIT(31)
+-#define AQ_RX_PD_LEN_MASK	0x7FFF0000
+-#define AQ_RX_PD_LEN_SHIFT	0x10
+-#define AQ_RX_PD_VLAN_SHIFT	0x20
+-
+-/* RX Descriptor header */
+-#define AQ_RX_DH_PKT_CNT_MASK		0x1FFF
+-#define AQ_RX_DH_DESC_OFFSET_MASK	0xFFFFE000
+-#define AQ_RX_DH_DESC_OFFSET_SHIFT	0x0D
+-
+-static struct {
+-	unsigned char ctrl;
+-	unsigned char timer_l;
+-	unsigned char timer_h;
+-	unsigned char size;
+-	unsigned char ifg;
+-} AQC111_BULKIN_SIZE[] = {
+-	/* xHCI & EHCI & OHCI */
+-	{7, 0x00, 0x01, 0x1E, 0xFF},/* 10G, 5G, 2.5G, 1G */
+-	{7, 0xA0, 0x00, 0x14, 0x00},/* 100M */
+-	/* Jumbo packet */
+-	{7, 0x00, 0x01, 0x18, 0xFF},
+-};
+-
+-#endif /* __LINUX_USBNET_AQC111_H */
+diff -uNr aqc111u-1.3.3.0/aqc111u.c aqc111u-1.3.3.0-patch/aqc111u.c
+--- aqc111u-1.3.3.0/aqc111u.c	1969-12-31 16:00:00.000000000 -0800
++++ aqc111u-1.3.3.0-patch/aqc111u.c	2021-04-18 15:48:23.000000000 -0700
+@@ -0,0 +1,1844 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/* Aquantia Corp. Aquantia AQtion USB to 5GbE Controller
++ * Copyright (C) 2003-2005 David Hollis <dhollis@davehollis.com>
++ * Copyright (C) 2005 Phil Chang <pchang23@sbcglobal.net>
++ * Copyright (C) 2002-2003 TiVo Inc.
++ * Copyright (C) 2017-2018 ASIX
++ * Copyright (C) 2018 Aquantia Corp.
++ */
++
++#include <linux/version.h>
++#include <linux/module.h>
++#include <linux/netdevice.h>
++#include <linux/ethtool.h>
++#include <linux/mii.h>
++#include <linux/usb.h>
++#include <linux/crc32.h>
++#include <linux/if_vlan.h>
++#include <linux/usb/cdc.h>
++#include <linux/workqueue.h>
++
++#include "aq_compat.h"
++#include "aqc111u.h"
++
++#define DRIVER_VERSION "1.3.3.0"
++#define DRIVER_NAME "aqc111u"
++
++static int aqc111_read_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
++				u16 index, u16 size, void *data)
++{
++	int ret;
++
++	ret = usbnet_read_cmd_nopm(dev, cmd, USB_DIR_IN | USB_TYPE_VENDOR |
++				   USB_RECIP_DEVICE, value, index, data, size);
++
++	if (unlikely(ret < 0))
++		netdev_warn(dev->net,
++			    "Failed to read(0x%x) reg index 0x%04x: %d\n",
++			    cmd, index, ret);
++
++	return ret;
++}
++
++static int aqc111_read_cmd(struct usbnet *dev, u8 cmd, u16 value,
++			   u16 index, u16 size, void *data)
++{
++	int ret;
++
++	ret = usbnet_read_cmd(dev, cmd, USB_DIR_IN | USB_TYPE_VENDOR |
++			      USB_RECIP_DEVICE, value, index, data, size);
++
++	if (unlikely(ret < 0))
++		netdev_warn(dev->net,
++			    "Failed to read(0x%x) reg index 0x%04x: %d\n",
++			    cmd, index, ret);
++
++	return ret;
++}
++
++static int aqc111_read16_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
++				  u16 index, u16 *data)
++{
++	int ret = 0;
++
++	ret = aqc111_read_cmd_nopm(dev, cmd, value, index, sizeof(*data), data);
++	le16_to_cpus(data);
++
++	return ret;
++}
++
++static int aqc111_read16_cmd(struct usbnet *dev, u8 cmd, u16 value,
++			     u16 index, u16 *data)
++{
++	int ret = 0;
++
++	ret = aqc111_read_cmd(dev, cmd, value, index, sizeof(*data), data);
++	le16_to_cpus(data);
++
++	return ret;
++}
++
++static int __aqc111_write_cmd(struct usbnet *dev, u8 cmd, u8 reqtype,
++			      u16 value, u16 index, u16 size, const void *data)
++{
++	int err = -ENOMEM;
++	void *buf = NULL;
++
++	netdev_dbg(dev->net,
++		   "%s cmd=%#x reqtype=%#x value=%#x index=%#x size=%d\n",
++		   __func__, cmd, reqtype, value, index, size);
++
++	if (data) {
++		buf = kmemdup(data, size, GFP_KERNEL);
++		if (!buf)
++			goto out;
++	}
++
++	err = usb_control_msg(dev->udev, usb_sndctrlpipe(dev->udev, 0),
++			      cmd, reqtype, value, index, buf, size,
++			      (cmd == AQ_PHY_POWER) ? AQ_USB_PHY_SET_TIMEOUT :
++			      AQ_USB_SET_TIMEOUT);
++
++	if (unlikely(err < 0))
++		netdev_warn(dev->net,
++			    "Failed to write(0x%x) reg index 0x%04x: %d\n",
++			    cmd, index, err);
++	kfree(buf);
++
++out:
++	return err;
++}
++
++static int aqc111_write_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
++				 u16 index, u16 size, void *data)
++{
++	int ret;
++
++	ret = __aqc111_write_cmd(dev, cmd, USB_DIR_OUT | USB_TYPE_VENDOR |
++				 USB_RECIP_DEVICE, value, index, size, data);
++
++	return ret;
++}
++
++static int aqc111_write_cmd(struct usbnet *dev, u8 cmd, u16 value,
++			    u16 index, u16 size, void *data)
++{
++	int ret;
++
++	if (usb_autopm_get_interface(dev->intf) < 0)
++		return -ENODEV;
++
++	ret = __aqc111_write_cmd(dev, cmd, USB_DIR_OUT | USB_TYPE_VENDOR |
++				 USB_RECIP_DEVICE, value, index, size, data);
++
++	usb_autopm_put_interface(dev->intf);
++
++	return ret;
++}
++
++static int aqc111_write16_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
++				   u16 index, u16 *data)
++{
++	u16 tmp = *data;
++
++	cpu_to_le16s(&tmp);
++
++	return aqc111_write_cmd_nopm(dev, cmd, value, index, sizeof(tmp), &tmp);
++}
++
++static int aqc111_write16_cmd(struct usbnet *dev, u8 cmd, u16 value,
++			      u16 index, u16 *data)
++{
++	u16 tmp = *data;
++
++	cpu_to_le16s(&tmp);
++
++	return aqc111_write_cmd(dev, cmd, value, index, sizeof(tmp), &tmp);
++}
++
++static int aqc111_write32_cmd_nopm(struct usbnet *dev, u8 cmd, u16 value,
++				   u16 index, u32 *data)
++{
++	u32 tmp = *data;
++
++	cpu_to_le32s(&tmp);
++
++	return aqc111_write_cmd_nopm(dev, cmd, value, index, sizeof(tmp), &tmp);
++}
++
++static int aqc111_write32_cmd(struct usbnet *dev, u8 cmd, u16 value,
++			      u16 index, u32 *data)
++{
++	u32 tmp = *data;
++
++	cpu_to_le32s(&tmp);
++
++	return aqc111_write_cmd(dev, cmd, value, index, sizeof(tmp), &tmp);
++}
++
++static int aqc111_write_cmd_async(struct usbnet *dev, u8 cmd, u16 value,
++				  u16 index, u16 size, void *data)
++{
++	return usbnet_write_cmd_async(dev, cmd, USB_DIR_OUT | USB_TYPE_VENDOR |
++				      USB_RECIP_DEVICE, value, index, data,
++				      size);
++}
++
++static int aqc111_write16_cmd_async(struct usbnet *dev, u8 cmd, u16 value,
++				    u16 index, u16 *data)
++{
++	u16 tmp = *data;
++
++	cpu_to_le16s(&tmp);
++
++	return aqc111_write_cmd_async(dev, cmd, value, index,
++				      sizeof(tmp), &tmp);
++}
++
++static int aqc111_mdio_read(struct usbnet *dev, u16 value, u16 index, u16 *data)
++{
++	return aqc111_read16_cmd(dev, AQ_PHY_CMD, value, index, data);
++}
++
++static int aqc111_mdio_write(struct usbnet *dev, u16 value,
++			     u16 index, u16 *data)
++{
++	return aqc111_write16_cmd(dev, AQ_PHY_CMD, value, index, data);
++}
++
++#if KERNEL_VERSION(4, 6, 0) > LINUX_VERSION_CODE
++static int aqc111_get_settings(struct net_device *net, struct ethtool_cmd *cmd)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	struct mii_if_info *mii = &dev->mii;
++	u32 speed = SPEED_UNKNOWN;
++
++	cmd->supported =
++		(SUPPORTED_100baseT_Full |
++		 SUPPORTED_1000baseT_Full |
++		 SUPPORTED_Autoneg | SUPPORTED_TP | SUPPORTED_MII);
++
++	/* only supports twisted-pair */
++	cmd->port = PORT_MII;
++
++	/* only supports internal transceiver */
++	cmd->transceiver = XCVR_INTERNAL;
++
++	/* this isn't fully supported at higher layers */
++	cmd->phy_address = mii->phy_id;
++	cmd->mdio_support = 0x00; /*Not supported*/
++
++	cmd->advertising =
++		(ADVERTISED_100baseT_Full |
++		 ADVERTISED_1000baseT_Full |
++		 ADVERTISED_Autoneg | ADVERTISED_TP | ADVERTISED_MII);
++
++	cmd->autoneg = aqc111_data->autoneg;
++
++	switch (aqc111_data->link_speed) {
++	case AQ_INT_SPEED_5G:
++		speed = SPEED_5000;
++		break;
++	case AQ_INT_SPEED_2_5G:
++		speed = SPEED_2500;
++		break;
++	case AQ_INT_SPEED_1G:
++		speed = SPEED_1000;
++		break;
++	case AQ_INT_SPEED_100M:
++		speed = SPEED_100;
++		break;
++	}
++	cmd->duplex = DUPLEX_FULL;
++
++	ethtool_cmd_speed_set(cmd, speed);
++
++	mii->full_duplex = cmd->duplex;
++
++	return 0;
++}
++#endif
++
++static void aqc111_get_drvinfo(struct net_device *net,
++			       struct ethtool_drvinfo *info)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++
++	/* Inherit standard device info */
++	usbnet_get_drvinfo(net, info);
++	strlcpy(info->driver, DRIVER_NAME, sizeof(info->driver));
++	strlcpy(info->version, DRIVER_VERSION, sizeof(info->version));
++	snprintf(info->fw_version, sizeof(info->fw_version), "%u.%u.%u",
++		 aqc111_data->fw_ver.major,
++		 aqc111_data->fw_ver.minor,
++		 aqc111_data->fw_ver.rev);
++	info->eedump_len = 0x00;
++	info->regdump_len = 0x00;
++}
++
++static void aqc111_get_wol(struct net_device *net,
++			   struct ethtool_wolinfo *wolinfo)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++
++	wolinfo->supported = WAKE_MAGIC;
++	wolinfo->wolopts = 0;
++
++	if (aqc111_data->wol_flags & AQ_WOL_FLAG_MP)
++		wolinfo->wolopts |= WAKE_MAGIC;
++}
++
++static int aqc111_set_wol(struct net_device *net,
++			  struct ethtool_wolinfo *wolinfo)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++
++	if (wolinfo->wolopts & ~WAKE_MAGIC)
++		return -EINVAL;
++
++	aqc111_data->wol_flags = 0;
++	if (wolinfo->wolopts & WAKE_MAGIC)
++		aqc111_data->wol_flags |= AQ_WOL_FLAG_MP;
++
++	return 0;
++}
++
++static const char aqc111_priv_flag_names[][ETH_GSTRING_LEN] = {
++	"Low Power 5G",
++	"Thermal throttling",
++};
++
++static void aqc111_get_strings(struct net_device *net, u32 stringset, u8 *data)
++{
++	switch (stringset) {
++	case  ETH_SS_PRIV_FLAGS:
++		memcpy(data, aqc111_priv_flag_names,
++		       sizeof(aqc111_priv_flag_names));
++		break;
++	}
++}
++
++static u32 aqc111_get_priv_flags(struct net_device *net)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++
++	return aqc111_data->priv_flags;
++}
++
++static void aqc111_set_phy_speed_fw_iface(struct usbnet *dev,
++					  struct aqc111_data *aqc111_data)
++{
++	aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0, &aqc111_data->phy_cfg);
++}
++
++static void aqc111_set_phy_speed_direct(struct usbnet *dev,
++					struct aqc111_data *aqc111_data)
++{
++	u16 reg16_1 = 0;
++	u16 reg16_2 = 0;
++	u16 reg16_3 = 0;
++
++	/* Disable auto-negotiation */
++	reg16_1 = AQ_ANEG_EX_PAGE_CTRL;
++	aqc111_mdio_write(dev, AQ_AUTONEG_STD_CTRL_REG, AQ_PHY_AUTONEG_ADDR,
++			  &reg16_1);
++
++	reg16_1 = AQ_ANEG_EX_PHY_ID | AQ_ANEG_ADV_AQRATE;
++	if (aqc111_data->phy_cfg & AQ_DOWNSHIFT) {
++		reg16_1 |= AQ_ANEG_EN_DSH;
++		reg16_1 |= (aqc111_data->phy_cfg & AQ_DSH_RETRIES_MASK) >>
++			    AQ_DSH_RETRIES_SHIFT;
++	}
++
++	reg16_2 = AQ_ANEG_ADV_LT;
++	if (aqc111_data->phy_cfg & AQ_PAUSE)
++		reg16_3 |= AQ_ANEG_PAUSE;
++
++	if (aqc111_data->phy_cfg & AQ_ASYM_PAUSE)
++		reg16_3 |= AQ_ANEG_ASYM_PAUSE;
++
++	if (aqc111_data->phy_cfg & AQ_ADV_5G) {
++		reg16_1 |= AQ_ANEG_ADV_5G_N;
++		reg16_2 |= AQ_ANEG_ADV_5G_T;
++	}
++	if (aqc111_data->phy_cfg & AQ_ADV_2G5) {
++		reg16_1 |= AQ_ANEG_ADV_2G5_N;
++		reg16_2 |= AQ_ANEG_ADV_2G5_T;
++	}
++	if (aqc111_data->phy_cfg & AQ_ADV_1G)
++		reg16_1 |= AQ_ANEG_ADV_1G;
++
++	if (aqc111_data->phy_cfg & AQ_ADV_100M)
++		reg16_3 |= AQ_ANEG_100M;
++
++	aqc111_mdio_write(dev, AQ_AUTONEG_VEN_PROV1_REG,
++			  AQ_PHY_AUTONEG_ADDR, &reg16_1);
++	aqc111_mdio_write(dev, AQ_AUTONEG_10GT_CTRL_REG,
++			  AQ_PHY_AUTONEG_ADDR, &reg16_2);
++
++	aqc111_mdio_read(dev, AQ_GLB_SYS_CFG_REG_5G, AQ_PHY_GLOBAL_ADDR,
++			 &reg16_1);
++	reg16_1 &= ~AQ_SERDES_MODE_MASK;
++	if (aqc111_data->phy_cfg & AQ_XFI_DIV_2)
++		reg16_1 |= AQ_SERDES_MODE_XFI_DIV_2;
++	else
++		reg16_1 |= AQ_SERDES_MODE_XFI;
++
++	aqc111_mdio_write(dev, AQ_GLB_SYS_CFG_REG_5G, AQ_PHY_GLOBAL_ADDR,
++			  &reg16_1);
++
++	aqc111_mdio_read(dev, AQ_AUTONEG_ADV_REG, AQ_PHY_AUTONEG_ADDR,
++			 &reg16_1);
++	reg16_1 &= ~AQ_ANEG_ABILITY_MASK;
++	reg16_1 |= reg16_3;
++	aqc111_mdio_write(dev, AQ_AUTONEG_ADV_REG, AQ_PHY_AUTONEG_ADDR,
++			  &reg16_1);
++
++	/* Restart auto-negotiation */
++	reg16_1 = AQ_ANEG_EX_PAGE_CTRL | AQ_ANEG_EN_ANEG |
++		  AQ_ANEG_RESTART_ANEG;
++
++	aqc111_mdio_write(dev, AQ_AUTONEG_STD_CTRL_REG,
++			  AQ_PHY_AUTONEG_ADDR, &reg16_1);
++}
++
++static void aqc111_set_phy_speed(struct usbnet *dev, u8 autoneg, u16 speed)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++
++	aqc111_data->phy_cfg &= ~AQ_ADV_MASK;
++	aqc111_data->phy_cfg |= AQ_PAUSE;
++	aqc111_data->phy_cfg |= AQ_ASYM_PAUSE;
++	aqc111_data->phy_cfg |= AQ_DOWNSHIFT;
++	aqc111_data->phy_cfg &= ~AQ_DSH_RETRIES_MASK;
++	aqc111_data->phy_cfg |= (3 << AQ_DSH_RETRIES_SHIFT) &
++				AQ_DSH_RETRIES_MASK;
++
++	aqc111_data->phy_cfg &= ~AQ_XFI_DIV_2;
++	if (aqc111_data->priv_flags & AQ_PF_XFI_DIV_2)
++		aqc111_data->phy_cfg |= AQ_XFI_DIV_2;
++
++	if (autoneg == AUTONEG_ENABLE) {
++		switch (speed) {
++		case SPEED_5000:
++			aqc111_data->phy_cfg |= AQ_ADV_5G;
++			/* fall-through */
++		case SPEED_2500:
++			aqc111_data->phy_cfg |= AQ_ADV_2G5;
++			/* fall-through */
++		case SPEED_1000:
++			aqc111_data->phy_cfg |= AQ_ADV_1G;
++			/* fall-through */
++		case SPEED_100:
++			aqc111_data->phy_cfg |= AQ_ADV_100M;
++			/* fall-through */
++		}
++	} else {
++		switch (speed) {
++		case SPEED_5000:
++			aqc111_data->phy_cfg |= AQ_ADV_5G;
++			break;
++		case SPEED_2500:
++			aqc111_data->phy_cfg |= AQ_ADV_2G5;
++			break;
++		case SPEED_1000:
++			aqc111_data->phy_cfg |= AQ_ADV_1G;
++			break;
++		case SPEED_100:
++			aqc111_data->phy_cfg |= AQ_ADV_100M;
++			break;
++		}
++	}
++
++	if (aqc111_data->dpa)
++		aqc111_set_phy_speed_direct(dev, aqc111_data);
++	else
++		aqc111_set_phy_speed_fw_iface(dev, aqc111_data);
++}
++
++static int aqc111_update_thermal_params(struct usbnet *dev)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	struct aqc111_thermal_params therm_params = {};
++
++	therm_params.enable = (aqc111_data->priv_flags & AQ_PF_THERMAL) ? 1 : 0;
++	therm_params.threshold_critical = AQ_CRITICAL_TEMP_THRESHOLD;
++	therm_params.threshold_high = AQ_HIGH_TEMP_THRESHOLD;
++	therm_params.threshold_normal = AQ_NORMAL_TEMP_THRESHOLD;
++	therm_params.phy_speed_mask = AQ_ADV_100M;
++	return aqc111_write_cmd(dev, AQ_PHY_THERMAL, 0, 0,
++				sizeof(struct aqc111_thermal_params),
++				&therm_params);
++}
++
++static int aqc111_set_priv_flags(struct net_device *net, u32 flags)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u32 changed;
++
++	if (flags & ~AQ_PRIV_FLAGS_MASK)
++		return -EOPNOTSUPP;
++
++	changed = aqc111_data->priv_flags^flags;
++	aqc111_data->priv_flags = flags;
++
++	if (!(aqc111_data->phy_cfg & AQ_LOW_POWER) &&
++	    (aqc111_data->phy_cfg & AQ_PHY_POWER_EN)) {
++		if (changed & AQ_PF_XFI_DIV_2) {
++			aqc111_set_phy_speed(dev, aqc111_data->autoneg,
++					     aqc111_data->advertised_speed);
++		}
++	}
++	if (changed & AQ_PF_THERMAL)
++		aqc111_update_thermal_params(dev);
++
++	return 0;
++}
++
++static int aqc111_get_sset_count(struct net_device *net, int stringset)
++{
++	int ret = 0;
++
++	switch (stringset) {
++	case ETH_SS_PRIV_FLAGS:
++		ret = ARRAY_SIZE(aqc111_priv_flag_names);
++		break;
++	default:
++		ret = -EOPNOTSUPP;
++	}
++
++	return ret;
++}
++
++#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
++static void aqc111_speed_to_link_mode(u32 speed,
++				      struct ethtool_link_ksettings *elk)
++{
++	switch (speed) {
++#if KERNEL_VERSION(4, 10, 0) <= LINUX_VERSION_CODE
++	case SPEED_5000:
++		ethtool_link_ksettings_add_link_mode(elk, advertising,
++						     5000baseT_Full);
++		break;
++	case SPEED_2500:
++		ethtool_link_ksettings_add_link_mode(elk, advertising,
++						     2500baseT_Full);
++		break;
++#endif
++	case SPEED_1000:
++		ethtool_link_ksettings_add_link_mode(elk, advertising,
++						     1000baseT_Full);
++		break;
++	case SPEED_100:
++		ethtool_link_ksettings_add_link_mode(elk, advertising,
++						     100baseT_Full);
++		break;
++	}
++}
++
++static int aqc111_get_link_ksettings(struct net_device *net,
++				     struct ethtool_link_ksettings *elk)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	enum usb_device_speed usb_speed = dev->udev->speed;
++	u32 speed = SPEED_UNKNOWN;
++
++	ethtool_link_ksettings_zero_link_mode(elk, supported);
++	ethtool_link_ksettings_add_link_mode(elk, supported,
++					     100baseT_Full);
++	ethtool_link_ksettings_add_link_mode(elk, supported,
++					     1000baseT_Full);
++#if KERNEL_VERSION(4, 10, 0) <= LINUX_VERSION_CODE
++	if (usb_speed == USB_SPEED_SUPER) {
++		ethtool_link_ksettings_add_link_mode(elk, supported,
++						     2500baseT_Full);
++		ethtool_link_ksettings_add_link_mode(elk, supported,
++						     5000baseT_Full);
++	}
++#endif
++	ethtool_link_ksettings_add_link_mode(elk, supported, TP);
++	ethtool_link_ksettings_add_link_mode(elk, supported, Autoneg);
++
++	elk->base.port = PORT_TP;
++#if KERNEL_VERSION(4, 14, 0) <= LINUX_VERSION_CODE
++	elk->base.transceiver = XCVR_INTERNAL;
++#endif
++
++	elk->base.mdio_support = 0x00; /*Not supported*/
++
++	if (aqc111_data->autoneg)
++		linkmode_copy(elk->link_modes.advertising,
++			      elk->link_modes.supported);
++	else
++		aqc111_speed_to_link_mode(aqc111_data->advertised_speed, elk);
++
++	elk->base.autoneg = aqc111_data->autoneg;
++
++	switch (aqc111_data->link_speed) {
++	case AQ_INT_SPEED_5G:
++		speed = SPEED_5000;
++		break;
++	case AQ_INT_SPEED_2_5G:
++		speed = SPEED_2500;
++		break;
++	case AQ_INT_SPEED_1G:
++		speed = SPEED_1000;
++		break;
++	case AQ_INT_SPEED_100M:
++		speed = SPEED_100;
++		break;
++	}
++	elk->base.duplex = DUPLEX_FULL;
++	elk->base.speed = speed;
++
++	return 0;
++}
++#endif
++
++#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
++static int aqc111_set_link_ksettings(struct net_device *net,
++				     const struct ethtool_link_ksettings *elk)
++#else
++static int aqc111_set_settings(struct net_device *net, struct ethtool_cmd *cmd)
++#endif
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	enum usb_device_speed usb_speed = dev->udev->speed;
++#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
++	u8 autoneg = elk->base.autoneg;
++	u32 speed = elk->base.speed;
++	u8 duplex = elk->base.duplex;
++#else
++	u16 speed = ethtool_cmd_speed(cmd);
++	u8 autoneg = cmd->autoneg;
++	u8 duplex = cmd->duplex;
++#endif
++	if (autoneg == AUTONEG_ENABLE) {
++		if (aqc111_data->autoneg != AUTONEG_ENABLE) {
++			aqc111_data->autoneg = AUTONEG_ENABLE;
++			aqc111_data->advertised_speed =
++					(usb_speed == USB_SPEED_SUPER) ?
++					 SPEED_5000 : SPEED_1000;
++			aqc111_set_phy_speed(dev, aqc111_data->autoneg,
++					     aqc111_data->advertised_speed);
++		}
++	} else {
++		if (speed != SPEED_100 &&
++		    speed != SPEED_1000 &&
++		    speed != SPEED_2500 &&
++		    speed != SPEED_5000 &&
++		    speed != SPEED_UNKNOWN)
++			return -EINVAL;
++
++		if (duplex != DUPLEX_FULL)
++			return -EINVAL;
++
++		if (usb_speed != USB_SPEED_SUPER && speed > SPEED_1000)
++			return -EINVAL;
++
++		aqc111_data->autoneg = AUTONEG_DISABLE;
++		if (speed != SPEED_UNKNOWN)
++			aqc111_data->advertised_speed = speed;
++
++		aqc111_set_phy_speed(dev, aqc111_data->autoneg,
++				     aqc111_data->advertised_speed);
++	}
++
++	return 0;
++}
++
++static const struct ethtool_ops aqc111_ethtool_ops = {
++#if KERNEL_VERSION(4, 6, 0) > LINUX_VERSION_CODE
++	.get_settings = aqc111_get_settings,
++	.set_settings = aqc111_set_settings,
++#endif
++	.get_drvinfo = aqc111_get_drvinfo,
++	.get_wol = aqc111_get_wol,
++	.set_wol = aqc111_set_wol,
++	.get_msglevel = usbnet_get_msglevel,
++	.set_msglevel = usbnet_set_msglevel,
++	.get_link = ethtool_op_get_link,
++	.get_strings = aqc111_get_strings,
++	.get_priv_flags = aqc111_get_priv_flags,
++	.set_priv_flags = aqc111_set_priv_flags,
++	.get_sset_count = aqc111_get_sset_count,
++#if KERNEL_VERSION(4, 6, 0) <= LINUX_VERSION_CODE
++	.get_link_ksettings = aqc111_get_link_ksettings,
++	.set_link_ksettings = aqc111_set_link_ksettings
++#endif
++};
++
++static int aqc111_change_mtu(struct net_device *net, int new_mtu)
++{
++	struct usbnet *dev = netdev_priv(net);
++	u16 reg16 = 0;
++	u8 buf[5];
++
++#if KERNEL_VERSION(4, 10, 0) > LINUX_VERSION_CODE
++	if (new_mtu <= 0 || new_mtu > 16334)
++		return -EINVAL;
++#endif
++
++	net->mtu = new_mtu;
++	dev->hard_mtu = net->mtu + net->hard_header_len;
++
++	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++			  2, &reg16);
++	if (net->mtu > 1500)
++		reg16 |= SFR_MEDIUM_JUMBO_EN;
++	else
++		reg16 &= ~SFR_MEDIUM_JUMBO_EN;
++
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++			   2, &reg16);
++
++	if (dev->net->mtu > 12500 && dev->net->mtu <= 16334) {
++		memcpy(buf, &AQC111_BULKIN_SIZE[2], 5);
++		/* RX bulk configuration */
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QCTRL,
++				 5, 5, buf);
++	}
++
++	/* Set high low water level */
++	if (dev->net->mtu <= 4500)
++		reg16 = 0x0810;
++	else if (dev->net->mtu <= 9500)
++		reg16 = 0x1020;
++	else if (dev->net->mtu <= 12500)
++		reg16 = 0x1420;
++	else if (dev->net->mtu <= 16334)
++		reg16 = 0x1A20;
++
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_PAUSE_WATERLVL_LOW,
++			   2, &reg16);
++
++	return 0;
++}
++
++static int aqc111_set_mac_addr(struct net_device *net, void *p)
++{
++	struct usbnet *dev = netdev_priv(net);
++	int ret = 0;
++
++	ret = eth_mac_addr(net, p);
++	if (ret < 0)
++		return ret;
++
++	/* Set the MAC address */
++	return aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_NODE_ID, ETH_ALEN,
++				ETH_ALEN, net->dev_addr);
++}
++
++static int aqc111_vlan_rx_kill_vid(struct net_device *net,
++				   __be16 proto, u16 vid)
++{
++	struct usbnet *dev = netdev_priv(net);
++	u8 vlan_ctrl = 0;
++	u16 reg16 = 0;
++	u8 reg8 = 0;
++
++	aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++	vlan_ctrl = reg8;
++
++	/* Address */
++	reg8 = (vid / 16);
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_ADDRESS, 1, 1, &reg8);
++	/* Data */
++	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_RD;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
++	reg16 &= ~(1 << (vid % 16));
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
++	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_WE;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++
++	return 0;
++}
++
++static int aqc111_vlan_rx_add_vid(struct net_device *net, __be16 proto, u16 vid)
++{
++	struct usbnet *dev = netdev_priv(net);
++	u8 vlan_ctrl = 0;
++	u16 reg16 = 0;
++	u8 reg8 = 0;
++
++	aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++	vlan_ctrl = reg8;
++
++	/* Address */
++	reg8 = (vid / 16);
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_ADDRESS, 1, 1, &reg8);
++	/* Data */
++	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_RD;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
++	reg16 |= (1 << (vid % 16));
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_DATA0, 2, &reg16);
++	reg8 = vlan_ctrl | SFR_VLAN_CONTROL_WE;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++
++	return 0;
++}
++
++static void aqc111_set_rx_mode(struct net_device *net)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	int mc_count = 0;
++
++	mc_count = netdev_mc_count(net);
++
++	aqc111_data->rxctl &= ~(SFR_RX_CTL_PRO | SFR_RX_CTL_AMALL |
++				SFR_RX_CTL_AM);
++
++	if (net->flags & IFF_PROMISC) {
++		aqc111_data->rxctl |= SFR_RX_CTL_PRO;
++	} else if ((net->flags & IFF_ALLMULTI) || mc_count > AQ_MAX_MCAST) {
++		aqc111_data->rxctl |= SFR_RX_CTL_AMALL;
++	} else if (!netdev_mc_empty(net)) {
++		u8 m_filter[AQ_MCAST_FILTER_SIZE] = { 0 };
++		struct netdev_hw_addr *ha = NULL;
++		u32 crc_bits = 0;
++
++		netdev_for_each_mc_addr(ha, net) {
++			crc_bits = ether_crc(ETH_ALEN, ha->addr) >> 26;
++			m_filter[crc_bits >> 3] |= BIT(crc_bits & 7);
++		}
++
++		aqc111_write_cmd_async(dev, AQ_ACCESS_MAC,
++				       SFR_MULTI_FILTER_ARRY,
++				       AQ_MCAST_FILTER_SIZE,
++				       AQ_MCAST_FILTER_SIZE, m_filter);
++
++		aqc111_data->rxctl |= SFR_RX_CTL_AM;
++	}
++
++	aqc111_write16_cmd_async(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
++				 2, &aqc111_data->rxctl);
++}
++
++static int aqc111_set_features(struct net_device *net,
++			       netdev_features_t features)
++{
++	struct usbnet *dev = netdev_priv(net);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	netdev_features_t changed = net->features ^ features;
++	u16 reg16 = 0;
++	u8 reg8 = 0;
++
++	if (changed & NETIF_F_IP_CSUM) {
++		aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL, 1, 1, &reg8);
++		reg8 ^= SFR_TXCOE_TCP | SFR_TXCOE_UDP;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL,
++				 1, 1, &reg8);
++	}
++
++	if (changed & NETIF_F_IPV6_CSUM) {
++		aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL, 1, 1, &reg8);
++		reg8 ^= SFR_TXCOE_TCPV6 | SFR_TXCOE_UDPV6;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL,
++				 1, 1, &reg8);
++	}
++
++	if (changed & NETIF_F_RXCSUM) {
++		aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_RXCOE_CTL, 1, 1, &reg8);
++		if (features & NETIF_F_RXCSUM) {
++			aqc111_data->rx_checksum = 1;
++			reg8 &= ~(SFR_RXCOE_IP | SFR_RXCOE_TCP | SFR_RXCOE_UDP |
++				  SFR_RXCOE_TCPV6 | SFR_RXCOE_UDPV6);
++		} else {
++			aqc111_data->rx_checksum = 0;
++			reg8 |= SFR_RXCOE_IP | SFR_RXCOE_TCP | SFR_RXCOE_UDP |
++				SFR_RXCOE_TCPV6 | SFR_RXCOE_UDPV6;
++		}
++
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RXCOE_CTL,
++				 1, 1, &reg8);
++	}
++	if (changed & NETIF_F_HW_VLAN_CTAG_FILTER) {
++		if (features & NETIF_F_HW_VLAN_CTAG_FILTER) {
++			u16 i = 0;
++
++			for (i = 0; i < 256; i++) {
++				/* Address */
++				reg8 = i;
++				aqc111_write_cmd(dev, AQ_ACCESS_MAC,
++						 SFR_VLAN_ID_ADDRESS,
++						 1, 1, &reg8);
++				/* Data */
++				aqc111_write16_cmd(dev, AQ_ACCESS_MAC,
++						   SFR_VLAN_ID_DATA0,
++						   2, &reg16);
++				reg8 = SFR_VLAN_CONTROL_WE;
++				aqc111_write_cmd(dev, AQ_ACCESS_MAC,
++						 SFR_VLAN_ID_CONTROL,
++						 1, 1, &reg8);
++			}
++			aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL,
++					1, 1, &reg8);
++			reg8 |= SFR_VLAN_CONTROL_VFE;
++			aqc111_write_cmd(dev, AQ_ACCESS_MAC,
++					 SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++		} else {
++			aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL,
++					1, 1, &reg8);
++			reg8 &= ~SFR_VLAN_CONTROL_VFE;
++			aqc111_write_cmd(dev, AQ_ACCESS_MAC,
++					 SFR_VLAN_ID_CONTROL, 1, 1, &reg8);
++		}
++	}
++
++	return 0;
++}
++
++static const struct net_device_ops aqc111_netdev_ops = {
++	.ndo_open		= usbnet_open,
++	.ndo_stop		= usbnet_stop,
++	.ndo_start_xmit		= usbnet_start_xmit,
++	.ndo_tx_timeout		= usbnet_tx_timeout,
++	.ndo_get_stats64	= usbnet_get_stats64,
++#if (RHEL_RELEASE_VERSION(7, 5) <= RHEL_RELEASE_CODE)
++	.extended.ndo_change_mtu = aqc111_change_mtu,
++	.ndo_size		= sizeof(const struct net_device_ops),
++#else
++	.ndo_change_mtu		= aqc111_change_mtu,
++#endif
++	.ndo_set_mac_address	= aqc111_set_mac_addr,
++	.ndo_validate_addr	= eth_validate_addr,
++	.ndo_vlan_rx_add_vid	= aqc111_vlan_rx_add_vid,
++	.ndo_vlan_rx_kill_vid	= aqc111_vlan_rx_kill_vid,
++	.ndo_set_rx_mode	= aqc111_set_rx_mode,
++	.ndo_set_features	= aqc111_set_features,
++};
++
++static int aqc111_read_perm_mac(struct usbnet *dev)
++{
++	u8 buf[ETH_ALEN];
++	int ret;
++
++	ret = aqc111_read_cmd(dev, AQ_FLASH_PARAMETERS, 0, 0, ETH_ALEN, buf);
++	if (ret < 0)
++		goto out;
++
++	ether_addr_copy(dev->net->perm_addr, buf);
++
++	return 0;
++out:
++	return ret;
++}
++
++static void aqc111_read_fw_version(struct usbnet *dev,
++				   struct aqc111_data *aqc111_data)
++{
++	aqc111_read_cmd(dev, AQ_ACCESS_MAC, AQ_FW_VER_MAJOR,
++			1, 1, &aqc111_data->fw_ver.major);
++	aqc111_read_cmd(dev, AQ_ACCESS_MAC, AQ_FW_VER_MINOR,
++			1, 1, &aqc111_data->fw_ver.minor);
++	aqc111_read_cmd(dev, AQ_ACCESS_MAC, AQ_FW_VER_REV,
++			1, 1, &aqc111_data->fw_ver.rev);
++
++	if (aqc111_data->fw_ver.major & 0x80)
++		aqc111_data->fw_ver.major &= ~0x80;
++	else
++		aqc111_data->dpa = 1;
++}
++
++static int aqc111_bind(struct usbnet *dev, struct usb_interface *intf)
++{
++	struct usb_device *udev = interface_to_usbdev(intf);
++	enum usb_device_speed usb_speed = udev->speed;
++	struct aqc111_data *aqc111_data;
++	int ret;
++
++	/* Force switch to LAN config */
++	aqc111_write_cmd(dev, AQ_SWITCH_CONFIG, AQ_SW_CONFIG_MAGIC_KEY,
++			 AQ_SW_CONFIG_LAN, 0, NULL);
++	/* Check if vendor configuration */
++	if (udev->actconfig->desc.bConfigurationValue != 1) {
++		usb_driver_set_configuration(udev, 1);
++		return -ENODEV;
++	}
++
++	usb_reset_configuration(dev->udev);
++
++	ret = usbnet_get_endpoints(dev, intf);
++	if (ret < 0) {
++		netdev_dbg(dev->net, "usbnet_get_endpoints failed");
++		return ret;
++	}
++
++	aqc111_data = kzalloc(sizeof(*aqc111_data), GFP_KERNEL);
++	if (!aqc111_data)
++		return -ENOMEM;
++
++	/* store aqc111_data pointer in device data field */
++	dev->driver_priv = aqc111_data;
++
++	/* Init the MAC address */
++	ret = aqc111_read_perm_mac(dev);
++	if (ret)
++		goto out;
++
++	ether_addr_copy(dev->net->dev_addr, dev->net->perm_addr);
++
++	/* Set Rx urb size */
++	dev->rx_urb_size = URB_SIZE;
++
++	/* Set TX needed headroom & tailroom */
++	dev->net->needed_headroom += sizeof(u64);
++	dev->net->needed_tailroom += sizeof(u64);
++
++#if KERNEL_VERSION(4, 10, 0) <= LINUX_VERSION_CODE
++	dev->net->max_mtu = 16334;
++#elif (RHEL_RELEASE_VERSION(7, 5) <= RHEL_RELEASE_CODE)
++	dev->net->extended->max_mtu = 16334;
++#endif
++
++	dev->net->netdev_ops = &aqc111_netdev_ops;
++	dev->net->ethtool_ops = &aqc111_ethtool_ops;
++
++#if KERNEL_VERSION(3, 12, 0) <= LINUX_VERSION_CODE || (RHEL_RELEASE_CODE)
++	if (usb_device_no_sg_constraint(dev->udev))
++		dev->can_dma_sg = 1;
++#endif
++
++	dev->net->hw_features |= AQ_SUPPORT_HW_FEATURE;
++	dev->net->features |= AQ_SUPPORT_FEATURE;
++	dev->net->vlan_features |= AQ_SUPPORT_VLAN_FEATURE;
++
++	aqc111_read_fw_version(dev, aqc111_data);
++	aqc111_data->autoneg = AUTONEG_ENABLE;
++	aqc111_data->advertised_speed = (usb_speed == USB_SPEED_SUPER) ?
++					 SPEED_5000 : SPEED_1000;
++	aqc111_data->priv_flags |= AQ_PF_THERMAL;
++	aqc111_data->rx_checksum = 1;
++
++	return 0;
++
++out:
++	kfree(aqc111_data);
++	return ret;
++}
++
++static void aqc111_unbind(struct usbnet *dev, struct usb_interface *intf)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u16 reg16;
++	u8 reg8;
++
++	/* Force bz */
++	reg16 = SFR_PHYPWR_RSTCTL_BZ;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
++				2, &reg16);
++	reg16 = 0;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
++				2, &reg16);
++
++	/* Power down ethernet PHY */
++	if (aqc111_data->dpa) {
++		reg8 = 0x00;
++		aqc111_write_cmd_nopm(dev, AQ_PHY_POWER, 0,
++				      0, 1, &reg8);
++	} else {
++		aqc111_data->phy_cfg &= ~AQ_ADV_MASK;
++		aqc111_data->phy_cfg |= AQ_LOW_POWER;
++		aqc111_data->phy_cfg &= ~AQ_PHY_POWER_EN;
++		aqc111_write32_cmd_nopm(dev, AQ_PHY_OPS, 0, 0,
++					&aqc111_data->phy_cfg);
++	}
++
++	kfree(aqc111_data);
++}
++
++static void aqc111_status(struct usbnet *dev, struct urb *urb)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u64 *event_data = NULL;
++	int link = 0;
++
++	if (urb->actual_length < sizeof(*event_data))
++		return;
++
++	event_data = urb->transfer_buffer;
++	le64_to_cpus(event_data);
++
++	if (*event_data & AQ_LS_MASK)
++		link = 1;
++	else
++		link = 0;
++
++	aqc111_data->link_speed = (*event_data & AQ_SPEED_MASK) >>
++				  AQ_SPEED_SHIFT;
++	aqc111_data->link = link;
++
++	if (netif_carrier_ok(dev->net) != link)
++		usbnet_defer_kevent(dev, EVENT_LINK_RESET);
++}
++
++static void aqc111_configure_rx(struct usbnet *dev,
++				struct aqc111_data *aqc111_data)
++{
++	enum usb_device_speed usb_speed = dev->udev->speed;
++	u16 link_speed = 0, usb_host = 0;
++	u8 buf[5] = { 0 };
++	u8 queue_num = 0;
++	u16 reg16 = 0;
++	u8 reg8 = 0;
++
++	buf[0] = 0x00;
++	buf[1] = 0xF8;
++	buf[2] = 0x07;
++	switch (aqc111_data->link_speed) {
++	case AQ_INT_SPEED_5G:
++		link_speed = 5000;
++		reg8 = 0x05;
++		reg16 = 0x001F;
++		break;
++	case AQ_INT_SPEED_2_5G:
++		link_speed = 2500;
++		reg16 = 0x003F;
++		break;
++	case AQ_INT_SPEED_1G:
++		link_speed = 1000;
++		reg16 = 0x009F;
++		break;
++	case AQ_INT_SPEED_100M:
++		link_speed = 100;
++		queue_num = 1;
++		reg16 = 0x063F;
++		buf[1] = 0xFB;
++		buf[2] = 0x4;
++		break;
++	}
++
++	if (aqc111_data->dpa) {
++		/* Set Phy Flow control */
++		aqc111_mdio_write(dev, AQ_GLB_ING_PAUSE_CTRL_REG,
++				  AQ_PHY_AUTONEG_ADDR, &reg16);
++		aqc111_mdio_write(dev, AQ_GLB_EGR_PAUSE_CTRL_REG,
++				  AQ_PHY_AUTONEG_ADDR, &reg16);
++	}
++
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_INTER_PACKET_GAP_0,
++			 1, 1, &reg8);
++
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TX_PAUSE_RESEND_T, 3, 3, buf);
++
++	switch (usb_speed) {
++	case USB_SPEED_SUPER:
++		usb_host = 3;
++		break;
++	case USB_SPEED_HIGH:
++		usb_host = 2;
++		break;
++	case USB_SPEED_FULL:
++	case USB_SPEED_LOW:
++		usb_host = 1;
++		queue_num = 0;
++		break;
++	default:
++		usb_host = 0;
++		break;
++	}
++
++	if (dev->net->mtu > 12500 && dev->net->mtu <= 16334)
++		queue_num = 2; /* For Jumbo packet 16KB */
++
++	memcpy(buf, &AQC111_BULKIN_SIZE[queue_num], 5);
++	/* RX bulk configuration */
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QCTRL, 5, 5, buf);
++
++	/* Set high low water level */
++	if (dev->net->mtu <= 4500)
++		reg16 = 0x0810;
++	else if (dev->net->mtu <= 9500)
++		reg16 = 0x1020;
++	else if (dev->net->mtu <= 12500)
++		reg16 = 0x1420;
++	else if (dev->net->mtu <= 16334)
++		reg16 = 0x1A20;
++
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_PAUSE_WATERLVL_LOW,
++			   2, &reg16);
++	netdev_info(dev->net, "Link Speed %d, USB %d", link_speed, usb_host);
++}
++
++static void aqc111_configure_csum_offload(struct usbnet *dev)
++{
++	u8 reg8 = 0;
++
++	if (dev->net->features & NETIF_F_RXCSUM) {
++		reg8 |= SFR_RXCOE_IP | SFR_RXCOE_TCP | SFR_RXCOE_UDP |
++			SFR_RXCOE_TCPV6 | SFR_RXCOE_UDPV6;
++	}
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_RXCOE_CTL, 1, 1, &reg8);
++
++	reg8 = 0;
++	if (dev->net->features & NETIF_F_IP_CSUM)
++		reg8 |= SFR_TXCOE_IP | SFR_TXCOE_TCP | SFR_TXCOE_UDP;
++
++	if (dev->net->features & NETIF_F_IPV6_CSUM)
++		reg8 |= SFR_TXCOE_TCPV6 | SFR_TXCOE_UDPV6;
++
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_TXCOE_CTL, 1, 1, &reg8);
++}
++
++static int aqc111_link_reset(struct usbnet *dev)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u16 reg16 = 0;
++	u8 reg8 = 0;
++
++	if (aqc111_data->link == 1) { /* Link up */
++		aqc111_configure_rx(dev, aqc111_data);
++
++		/* Vlan Tag Filter */
++		reg8 = SFR_VLAN_CONTROL_VSO;
++		if (dev->net->features & NETIF_F_HW_VLAN_CTAG_FILTER)
++			reg8 |= SFR_VLAN_CONTROL_VFE;
++
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_VLAN_ID_CONTROL,
++				 1, 1, &reg8);
++
++		reg8 = 0x0;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BMRX_DMA_CONTROL,
++				 1, 1, &reg8);
++
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BMTX_DMA_CONTROL,
++				 1, 1, &reg8);
++
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_ARC_CTRL, 1, 1, &reg8);
++
++		reg16 = SFR_RX_CTL_IPE | SFR_RX_CTL_AB;
++		aqc111_data->rxctl = reg16;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
++
++		reg8 = SFR_RX_PATH_READY;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
++				 1, 1, &reg8);
++
++		reg8 = SFR_BULK_OUT_EFF_EN;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
++				 1, 1, &reg8);
++
++		reg16 = 0;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				   2, &reg16);
++
++		reg16 = SFR_MEDIUM_XGMIIMODE | SFR_MEDIUM_FULL_DUPLEX;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				   2, &reg16);
++
++		aqc111_configure_csum_offload(dev);
++
++		aqc111_set_rx_mode(dev->net);
++
++		aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				  2, &reg16);
++
++		if (dev->net->mtu > 1500)
++			reg16 |= SFR_MEDIUM_JUMBO_EN;
++
++		reg16 |= SFR_MEDIUM_RECEIVE_EN | SFR_MEDIUM_RXFLOW_CTRLEN |
++			 SFR_MEDIUM_TXFLOW_CTRLEN;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				   2, &reg16);
++
++		aqc111_data->rxctl |= SFR_RX_CTL_START;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
++				   2, &aqc111_data->rxctl);
++
++		netif_carrier_on(dev->net);
++	} else {
++		aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				  2, &reg16);
++		reg16 &= ~SFR_MEDIUM_RECEIVE_EN;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				   2, &reg16);
++
++		aqc111_data->rxctl &= ~SFR_RX_CTL_START;
++		aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
++				   2, &aqc111_data->rxctl);
++
++		reg8 = SFR_BULK_OUT_FLUSH_EN | SFR_BULK_OUT_EFF_EN;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
++				 1, 1, &reg8);
++		reg8 = SFR_BULK_OUT_EFF_EN;
++		aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
++				 1, 1, &reg8);
++
++		netif_carrier_off(dev->net);
++	}
++	return 0;
++}
++
++static int aqc111_reset(struct usbnet *dev)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u16 reg16 = 0;
++	u8 reg8 = 0;
++
++	dev->rx_urb_size = URB_SIZE;
++
++#if KERNEL_VERSION(3, 12, 0) <= LINUX_VERSION_CODE || (RHEL_RELEASE_CODE)
++	if (usb_device_no_sg_constraint(dev->udev))
++		dev->can_dma_sg = 1;
++#endif
++
++	dev->net->hw_features |= AQ_SUPPORT_HW_FEATURE;
++	dev->net->features |= AQ_SUPPORT_FEATURE;
++	dev->net->vlan_features |= AQ_SUPPORT_VLAN_FEATURE;
++
++	/* Power up ethernet PHY */
++	aqc111_data->phy_cfg = AQ_PHY_POWER_EN;
++	if (aqc111_data->dpa) {
++		aqc111_read_cmd(dev, AQ_PHY_POWER, 0, 0, 1, &reg8);
++		if (reg8 == 0x00) {
++			reg8 = 0x02;
++			aqc111_write_cmd(dev, AQ_PHY_POWER, 0, 0, 1, &reg8);
++			msleep(200);
++		}
++
++		aqc111_mdio_read(dev, AQ_GLB_STD_CTRL_REG, AQ_PHY_GLOBAL_ADDR,
++				 &reg16);
++		if (reg16 & AQ_PHY_LOW_POWER_MODE) {
++			reg16 &= ~AQ_PHY_LOW_POWER_MODE;
++			aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG,
++					  AQ_PHY_GLOBAL_ADDR, &reg16);
++		}
++	} else {
++		aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
++				   &aqc111_data->phy_cfg);
++	}
++
++	/* Set the MAC address */
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_NODE_ID, ETH_ALEN,
++			 ETH_ALEN, dev->net->dev_addr);
++
++	reg8 = 0xFF;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BM_INT_MASK, 1, 1, &reg8);
++
++	reg8 = 0x0;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_SWP_CTRL, 1, 1, &reg8);
++
++	aqc111_read_cmd(dev, AQ_ACCESS_MAC, SFR_MONITOR_MODE, 1, 1, &reg8);
++	reg8 &= ~(SFR_MONITOR_MODE_EPHYRW | SFR_MONITOR_MODE_RWLC |
++		  SFR_MONITOR_MODE_RWMP | SFR_MONITOR_MODE_RWWF |
++		  SFR_MONITOR_MODE_RW_FLAG);
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_MONITOR_MODE, 1, 1, &reg8);
++
++	netif_carrier_off(dev->net);
++
++	aqc111_update_thermal_params(dev);
++
++	/* Phy advertise */
++	aqc111_set_phy_speed(dev, aqc111_data->autoneg,
++			     aqc111_data->advertised_speed);
++
++	return 0;
++}
++
++static int aqc111_stop(struct usbnet *dev)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u16 reg16 = 0;
++
++	aqc111_read16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++			  2, &reg16);
++	reg16 &= ~SFR_MEDIUM_RECEIVE_EN;
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++			   2, &reg16);
++	reg16 = 0;
++	aqc111_write16_cmd(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
++
++	/* Put PHY to low power*/
++	if (aqc111_data->dpa) {
++		reg16 = AQ_PHY_LOW_POWER_MODE;
++		aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG, AQ_PHY_GLOBAL_ADDR,
++				  &reg16);
++	} else {
++		aqc111_data->phy_cfg |= AQ_LOW_POWER;
++		aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
++				   &aqc111_data->phy_cfg);
++	}
++
++	netif_carrier_off(dev->net);
++
++	return 0;
++}
++
++static void aqc111_rx_checksum(struct sk_buff *skb, u64 *pkt_desc)
++{
++	u32 pkt_type = 0;
++
++	skb->ip_summed = CHECKSUM_NONE;
++	/* checksum error bit is set */
++	if (*pkt_desc & AQ_RX_PD_L4_ERR || *pkt_desc & AQ_RX_PD_L3_ERR)
++		return;
++
++	pkt_type = *pkt_desc & AQ_RX_PD_L4_TYPE_MASK;
++	/* It must be a TCP or UDP packet with a valid checksum */
++	if (pkt_type == AQ_RX_PD_L4_TCP || pkt_type == AQ_RX_PD_L4_UDP)
++		skb->ip_summed = CHECKSUM_UNNECESSARY;
++}
++
++static int aqc111_rx_fixup(struct usbnet *dev, struct sk_buff *skb)
++{
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	struct sk_buff *new_skb = NULL;
++	u32 pkt_total_offset = 0;
++	u32 start_of_descs = 0;
++	u64 *pkt_desc = NULL;
++	u32 desc_offset = 0; /*RX Header Offset*/
++	u16 pkt_count = 0;
++	u64 desc_hdr = 0;
++	u16 vlan_tag = 0;
++	u32 skb_len = 0;
++
++	if (!skb)
++		goto err;
++
++	if (skb->len == 0)
++		goto err;
++
++	skb_len = skb->len;
++	/* RX Descriptor Header */
++	skb_trim(skb, skb->len - sizeof(desc_hdr));
++	desc_hdr = *(u64 *)skb_tail_pointer(skb);
++	le64_to_cpus(&desc_hdr);
++
++	/* Check these packets */
++	desc_offset = (desc_hdr & AQ_RX_DH_DESC_OFFSET_MASK) >>
++		      AQ_RX_DH_DESC_OFFSET_SHIFT;
++	pkt_count = desc_hdr & AQ_RX_DH_PKT_CNT_MASK;
++	start_of_descs = skb_len - ((pkt_count + 1) *  sizeof(desc_hdr));
++
++	/* self check descs position */
++	if (start_of_descs != desc_offset)
++		goto err;
++
++	/* self check desc_offset from header*/
++	if (desc_offset >= skb_len)
++		goto err;
++
++	if (pkt_count == 0)
++		goto err;
++
++	/* Get the first RX packet descriptor */
++	pkt_desc = (u64 *)(skb->data + desc_offset);
++
++	while (pkt_count--) {
++		u32 pkt_len = 0;
++		u32 pkt_len_with_padd = 0;
++
++		le64_to_cpus(pkt_desc);
++		pkt_len = (u32)((*pkt_desc & AQ_RX_PD_LEN_MASK) >>
++			  AQ_RX_PD_LEN_SHIFT);
++		pkt_len_with_padd = ((pkt_len + 7) & 0x7FFF8);
++
++		pkt_total_offset += pkt_len_with_padd;
++		if (pkt_total_offset > desc_offset ||
++		    (pkt_count == 0 && pkt_total_offset != desc_offset)) {
++			goto err;
++		}
++
++		if (*pkt_desc & AQ_RX_PD_DROP ||
++		    !(*pkt_desc & AQ_RX_PD_RX_OK) ||
++		    pkt_len > (dev->hard_mtu + AQ_RX_HW_PAD))
++			goto next_desc;
++
++		new_skb = netdev_alloc_skb_ip_align(dev->net, pkt_len);
++
++		if (!new_skb)
++			goto err;
++
++		skb_put_data(new_skb, skb->data, pkt_len);
++		skb_pull(new_skb, AQ_RX_HW_PAD);
++
++		new_skb->truesize = SKB_TRUESIZE(new_skb->len);
++		if (aqc111_data->rx_checksum)
++			aqc111_rx_checksum(new_skb, pkt_desc);
++
++		if (*pkt_desc & AQ_RX_PD_VLAN) {
++			vlan_tag = *pkt_desc >> AQ_RX_PD_VLAN_SHIFT;
++			__vlan_hwaccel_put_tag(new_skb, htons(ETH_P_8021Q),
++					       vlan_tag & VLAN_VID_MASK);
++		}
++
++		usbnet_skb_return(dev, new_skb);
++		if (pkt_count == 0)
++			break;
++
++next_desc:
++		skb_pull(skb, pkt_len_with_padd);
++
++		/* Next RX Packet Descriptor */
++		pkt_desc++;
++
++		new_skb = NULL;
++	}
++
++	return 1;
++
++err:
++	return 0;
++}
++
++static struct sk_buff *aqc111_tx_fixup(struct usbnet *dev, struct sk_buff *skb,
++				       gfp_t flags)
++{
++	int frame_size = dev->maxpacket;
++	struct sk_buff *new_skb = NULL;
++	int padding_size = 0;
++	int headroom = 0;
++	int tailroom = 0;
++	u64 tx_desc = 0;
++	u16 tci = 0;
++
++	/*Length of actual data*/
++	tx_desc |= skb->len & AQ_TX_DESC_LEN_MASK;
++
++	/* TSO MSS */
++	tx_desc |= ((u64)(skb_shinfo(skb)->gso_size & AQ_TX_DESC_MSS_MASK)) <<
++		   AQ_TX_DESC_MSS_SHIFT;
++
++	headroom = (skb->len + sizeof(tx_desc)) % 8;
++	if (headroom != 0)
++		padding_size = 8 - headroom;
++
++	if (((skb->len + sizeof(tx_desc) + padding_size) % frame_size) == 0) {
++		padding_size += 8;
++		tx_desc |= AQ_TX_DESC_DROP_PADD;
++	}
++
++	/* Vlan Tag */
++	if (vlan_get_tag(skb, &tci) >= 0) {
++		tx_desc |= AQ_TX_DESC_VLAN;
++		tx_desc |= ((u64)tci & AQ_TX_DESC_VLAN_MASK) <<
++			   AQ_TX_DESC_VLAN_SHIFT;
++	}
++
++	if (
++#if KERNEL_VERSION(3, 12, 0) <= LINUX_VERSION_CODE || (RHEL_RELEASE_CODE)
++	    !dev->can_dma_sg &&
++#endif
++	    (dev->net->features & NETIF_F_SG) &&
++	    skb_linearize(skb))
++		return NULL;
++
++	headroom = skb_headroom(skb);
++	tailroom = skb_tailroom(skb);
++
++	if (!(headroom >= sizeof(tx_desc) && tailroom >= padding_size)) {
++		new_skb = skb_copy_expand(skb, sizeof(tx_desc),
++					  padding_size, flags);
++		dev_kfree_skb_any(skb);
++		skb = new_skb;
++		if (!skb)
++			return NULL;
++	}
++	if (padding_size != 0)
++		skb_put(skb, padding_size);
++	/* Copy TX header */
++	skb_push(skb, sizeof(tx_desc));
++	cpu_to_le64s(&tx_desc);
++	skb_copy_to_linear_data(skb, &tx_desc, sizeof(tx_desc));
++
++	usbnet_set_skb_tx_stats(skb, 1, 0);
++
++	return skb;
++}
++
++static const struct driver_info aqc111_info = {
++	.description	= "Aquantia AQtion USB to 5GbE Controller",
++	.bind		= aqc111_bind,
++	.unbind		= aqc111_unbind,
++	.status		= aqc111_status,
++	.link_reset	= aqc111_link_reset,
++	.reset		= aqc111_reset,
++	.stop		= aqc111_stop,
++	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
++			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
++	.rx_fixup	= aqc111_rx_fixup,
++	.tx_fixup	= aqc111_tx_fixup,
++};
++
++#define ASIX111_DESC \
++"ASIX USB 3.1 Gen1 to 5G Multi-Gigabit Ethernet Adapter"
++
++static const struct driver_info asix111_info = {
++	.description	= ASIX111_DESC,
++	.bind		= aqc111_bind,
++	.unbind		= aqc111_unbind,
++	.status		= aqc111_status,
++	.link_reset	= aqc111_link_reset,
++	.reset		= aqc111_reset,
++	.stop		= aqc111_stop,
++	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
++			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
++	.rx_fixup	= aqc111_rx_fixup,
++	.tx_fixup	= aqc111_tx_fixup,
++};
++
++#undef ASIX111_DESC
++
++#define ASIX112_DESC \
++"ASIX USB 3.1 Gen1 to 2.5G Multi-Gigabit Ethernet Adapter"
++
++static const struct driver_info asix112_info = {
++	.description	= ASIX112_DESC,
++	.bind		= aqc111_bind,
++	.unbind		= aqc111_unbind,
++	.status		= aqc111_status,
++	.link_reset	= aqc111_link_reset,
++	.reset		= aqc111_reset,
++	.stop		= aqc111_stop,
++	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
++			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
++	.rx_fixup	= aqc111_rx_fixup,
++	.tx_fixup	= aqc111_tx_fixup,
++};
++
++#undef ASIX112_DESC
++
++static const struct driver_info trendnet_info = {
++	.description	= "USB-C 3.1 to 5GBASE-T Ethernet Adapter",
++	.bind		= aqc111_bind,
++	.unbind		= aqc111_unbind,
++	.status		= aqc111_status,
++	.link_reset	= aqc111_link_reset,
++	.reset		= aqc111_reset,
++	.stop		= aqc111_stop,
++	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
++			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
++	.rx_fixup	= aqc111_rx_fixup,
++	.tx_fixup	= aqc111_tx_fixup,
++};
++
++static const struct driver_info qnap_info = {
++	.description	= "QNAP QNA-UC5G1T USB to 5GbE Adapter",
++	.bind		= aqc111_bind,
++	.unbind		= aqc111_unbind,
++	.status		= aqc111_status,
++	.link_reset	= aqc111_link_reset,
++	.reset		= aqc111_reset,
++	.stop		= aqc111_stop,
++	.flags		= FLAG_ETHER | FLAG_FRAMING_AX |
++			  FLAG_AVOID_UNLINK_URBS | FLAG_MULTI_PACKET,
++	.rx_fixup	= aqc111_rx_fixup,
++	.tx_fixup	= aqc111_tx_fixup,
++};
++
++static int aqc111_suspend(struct usb_interface *intf, pm_message_t message)
++{
++	struct usbnet *dev = usb_get_intfdata(intf);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u16 temp_rx_ctrl = 0x00;
++	u16 reg16;
++	u8 reg8;
++
++	usbnet_suspend(intf, message);
++
++	aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
++	temp_rx_ctrl = reg16;
++	/* Stop RX operations*/
++	reg16 &= ~SFR_RX_CTL_START;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
++	/* Force bz */
++	aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
++			       2, &reg16);
++	reg16 |= SFR_PHYPWR_RSTCTL_BZ;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_PHYPWR_RSTCTL,
++				2, &reg16);
++
++	reg8 = SFR_BULK_OUT_EFF_EN;
++	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BULK_OUT_CTRL,
++			      1, 1, &reg8);
++
++	temp_rx_ctrl &= ~(SFR_RX_CTL_START | SFR_RX_CTL_RF_WAK |
++			  SFR_RX_CTL_AP | SFR_RX_CTL_AM);
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
++				2, &temp_rx_ctrl);
++
++	reg8 = 0x00;
++	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
++			      1, 1, &reg8);
++
++	if (aqc111_data->wol_flags) {
++		struct aqc111_wol_cfg wol_cfg = { 0 };
++
++		aqc111_data->phy_cfg |= AQ_WOL;
++		if (aqc111_data->dpa) {
++			reg8 = 0;
++			if (aqc111_data->wol_flags & AQ_WOL_FLAG_MP)
++				reg8 |= SFR_MONITOR_MODE_RWMP;
++			aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC,
++					      SFR_MONITOR_MODE, 1, 1, &reg8);
++		} else {
++			ether_addr_copy(wol_cfg.hw_addr, dev->net->dev_addr);
++			wol_cfg.flags = aqc111_data->wol_flags;
++		}
++
++		temp_rx_ctrl |= (SFR_RX_CTL_AB | SFR_RX_CTL_START);
++		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL,
++					2, &temp_rx_ctrl);
++		reg8 = 0x00;
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BM_INT_MASK,
++				      1, 1, &reg8);
++		reg8 = SFR_BMRX_DMA_EN;
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BMRX_DMA_CONTROL,
++				      1, 1, &reg8);
++		reg8 = SFR_RX_PATH_READY;
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
++				      1, 1, &reg8);
++		reg8 = 0x07;
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QCTRL,
++				      1, 1, &reg8);
++		reg8 = 0x00;
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC,
++				      SFR_RX_BULKIN_QTIMR_LOW, 1, 1, &reg8);
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC,
++				      SFR_RX_BULKIN_QTIMR_HIGH, 1, 1, &reg8);
++		reg8 = 0xFF;
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QSIZE,
++				      1, 1, &reg8);
++		aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_BULKIN_QIFG,
++				      1, 1, &reg8);
++
++		aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC,
++				       SFR_MEDIUM_STATUS_MODE, 2, &reg16);
++		reg16 |= SFR_MEDIUM_RECEIVE_EN;
++		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC,
++					SFR_MEDIUM_STATUS_MODE, 2, &reg16);
++
++		if (aqc111_data->dpa) {
++			aqc111_set_phy_speed(dev, AUTONEG_ENABLE, SPEED_100);
++		} else {
++			aqc111_write_cmd(dev, AQ_WOL_CFG, 0, 0,
++					 WOL_CFG_SIZE, &wol_cfg);
++			aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
++					   &aqc111_data->phy_cfg);
++		}
++	} else {
++		aqc111_data->phy_cfg |= AQ_LOW_POWER;
++		if (!aqc111_data->dpa) {
++			aqc111_write32_cmd(dev, AQ_PHY_OPS, 0, 0,
++					   &aqc111_data->phy_cfg);
++		} else {
++			reg16 = AQ_PHY_LOW_POWER_MODE;
++			aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG,
++					  AQ_PHY_GLOBAL_ADDR, &reg16);
++		}
++
++		/* Disable RX path */
++		aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC,
++				       SFR_MEDIUM_STATUS_MODE, 2, &reg16);
++		reg16 &= ~SFR_MEDIUM_RECEIVE_EN;
++		aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC,
++					SFR_MEDIUM_STATUS_MODE, 2, &reg16);
++	}
++
++	return 0;
++}
++
++static int aqc111_resume(struct usb_interface *intf)
++{
++	struct usbnet *dev = usb_get_intfdata(intf);
++	struct aqc111_data *aqc111_data = dev->driver_priv;
++	u16 reg16;
++	u8 reg8;
++
++	netif_carrier_off(dev->net);
++
++	/* Power up ethernet PHY */
++	aqc111_data->phy_cfg |= AQ_PHY_POWER_EN;
++	aqc111_data->phy_cfg &= ~AQ_LOW_POWER;
++	aqc111_data->phy_cfg &= ~AQ_WOL;
++	if (aqc111_data->dpa) {
++		aqc111_read_cmd_nopm(dev, AQ_PHY_POWER, 0, 0, 1, &reg8);
++		if (reg8 == 0x00) {
++			reg8 = 0x02;
++			aqc111_write_cmd_nopm(dev, AQ_PHY_POWER, 0, 0,
++					      1, &reg8);
++			msleep(200);
++		}
++
++		aqc111_mdio_read(dev, AQ_GLB_STD_CTRL_REG, AQ_PHY_GLOBAL_ADDR,
++				 &reg16);
++		if (reg16 & AQ_PHY_LOW_POWER_MODE) {
++			reg16 &= ~AQ_PHY_LOW_POWER_MODE;
++			aqc111_mdio_write(dev, AQ_GLB_STD_CTRL_REG,
++					  AQ_PHY_GLOBAL_ADDR, &reg16);
++		}
++	}
++
++	reg8 = 0xFF;
++	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_BM_INT_MASK,
++			      1, 1, &reg8);
++	/* Configure RX control register => start operation */
++	reg16 = aqc111_data->rxctl;
++	reg16 &= ~SFR_RX_CTL_START;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
++
++	reg16 |= SFR_RX_CTL_START;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_RX_CTL, 2, &reg16);
++
++	aqc111_set_phy_speed(dev, aqc111_data->autoneg,
++			     aqc111_data->advertised_speed);
++
++	aqc111_read16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++			       2, &reg16);
++	reg16 |= SFR_MEDIUM_RECEIVE_EN;
++	aqc111_write16_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_MEDIUM_STATUS_MODE,
++				2, &reg16);
++	reg8 = SFR_RX_PATH_READY;
++	aqc111_write_cmd_nopm(dev, AQ_ACCESS_MAC, SFR_ETH_MAC_PATH,
++			      1, 1, &reg8);
++	reg8 = 0x0;
++	aqc111_write_cmd(dev, AQ_ACCESS_MAC, SFR_BMRX_DMA_CONTROL, 1, 1, &reg8);
++
++	return usbnet_resume(intf);
++}
++
++#define AQC111_USB_ETH_DEV(vid, pid, table) \
++	USB_DEVICE_INTERFACE_CLASS((vid), (pid), USB_CLASS_VENDOR_SPEC), \
++	.driver_info = (unsigned long)&(table) \
++}, \
++{ \
++	USB_DEVICE_AND_INTERFACE_INFO((vid), (pid), \
++				      USB_CLASS_COMM, \
++				      USB_CDC_SUBCLASS_ETHERNET, \
++				      USB_CDC_PROTO_NONE), \
++	.driver_info = (unsigned long)&(table),
++
++static const struct usb_device_id products[] = {
++	{AQC111_USB_ETH_DEV(0x2eca, 0xc101, aqc111_info)},
++	{AQC111_USB_ETH_DEV(0x0b95, 0x2790, asix111_info)},
++	{AQC111_USB_ETH_DEV(0x0b95, 0x2791, asix112_info)},
++	{AQC111_USB_ETH_DEV(0x20f4, 0xe05a, trendnet_info)},
++	{AQC111_USB_ETH_DEV(0x1c04, 0x0015, qnap_info)},
++	{ },/* END */
++};
++MODULE_DEVICE_TABLE(usb, products);
++
++static struct usb_driver aq_driver = {
++	.name		= "aqc111",
++	.id_table	= products,
++	.probe		= usbnet_probe,
++	.suspend	= aqc111_suspend,
++	.resume		= aqc111_resume,
++	.disconnect	= usbnet_disconnect,
++};
++
++module_usb_driver(aq_driver);
++
++MODULE_DESCRIPTION("Aquantia AQtion USB to 5/2.5GbE Controllers");
++MODULE_LICENSE("GPL");
+diff -uNr aqc111u-1.3.3.0/aqc111u.h aqc111u-1.3.3.0-patch/aqc111u.h
+--- aqc111u-1.3.3.0/aqc111u.h	1969-12-31 16:00:00.000000000 -0800
++++ aqc111u-1.3.3.0-patch/aqc111u.h	2021-04-18 15:48:35.000000000 -0700
+@@ -0,0 +1,308 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later
++ * Aquantia Corp. Aquantia AQtion USB to 5GbE Controller
++ * Copyright (C) 2003-2005 David Hollis <dhollis@davehollis.com>
++ * Copyright (C) 2005 Phil Chang <pchang23@sbcglobal.net>
++ * Copyright (C) 2002-2003 TiVo Inc.
++ * Copyright (C) 2017-2018 ASIX
++ * Copyright (C) 2018 Aquantia Corp.
++ */
++
++#ifndef __LINUX_USBNET_AQC111_H
++#define __LINUX_USBNET_AQC111_H
++
++#define URB_SIZE	(1024 * 62)
++
++#define AQ_MCAST_FILTER_SIZE		8
++#define AQ_MAX_MCAST			64
++
++#define AQ_ACCESS_MAC			0x01
++#define AQ_FLASH_PARAMETERS		0x20
++#define AQ_PHY_POWER			0x31
++#define AQ_PHY_CMD			0x32
++#define AQ_WOL_CFG			0x60
++#define AQ_PHY_OPS			0x61
++#define AQ_PHY_THERMAL			0x64
++#define AQ_USBDC_CMD			0x81
++#define AQ_SWITCH_CONFIG		0xB0
++
++#define AQC111_PHY_ID			0x00
++#define AQ_PHY_ADDR(mmd)		((AQC111_PHY_ID << 8) | mmd)
++
++#define AQ_PHY_AUTONEG_MMD		0x07
++#define AQ_PHY_AUTONEG_ADDR		AQ_PHY_ADDR(AQ_PHY_AUTONEG_MMD)
++
++#define AQ_AUTONEG_STD_CTRL_REG		0x0000
++	#define AQ_ANEG_EX_PAGE_CTRL		0x2000
++	#define AQ_ANEG_EN_ANEG			0x1000
++	#define AQ_ANEG_RESTART_ANEG		0x0200
++
++#define AQ_AUTONEG_ADV_REG		0x0010
++	#define AQ_ANEG_100M			0x0100
++	#define AQ_ANEG_PAUSE			0x0400
++	#define AQ_ANEG_ASYM_PAUSE		0x0800
++	#define AQ_ANEG_ABILITY_MASK		0x0FE0
++
++#define AQ_AUTONEG_10GT_CTRL_REG	0x0020
++	#define AQ_ANEG_ADV_10G_T		0x1000
++	#define AQ_ANEG_ADV_5G_T		0x0100
++	#define AQ_ANEG_ADV_2G5_T		0x0080
++	#define AQ_ANEG_ADV_LT			0x0001
++
++#define AQ_AUTONEG_VEN_PROV1_REG	0xC400
++	#define AQ_ANEG_ADV_1G			0x8000
++	#define AQ_ANEG_ADV_AQRATE		0x1000
++	#define AQ_ANEG_ADV_5G_N		0x0800
++	#define AQ_ANEG_ADV_2G5_N		0x0400
++	#define AQ_ANEG_EX_PHY_ID		0x0040
++	#define AQ_ANEG_EN_DSH			0x0010
++	#define AQ_ANEG_DSH_RETRY		0x0003
++
++#define AQ_PHY_GLOBAL_MMD		0x1E
++#define AQ_PHY_GLOBAL_ADDR		AQ_PHY_ADDR(AQ_PHY_GLOBAL_MMD)
++
++#define AQ_GLB_STD_CTRL_REG		0x0000
++	#define AQ_PHY_LOW_POWER_MODE		0x0800
++
++#define AQ_GLB_SYS_CFG_REG_5G		0x031E
++	#define AQ_SERDES_MODE_MASK		0x0007
++	#define AQ_SERDES_MODE_XFI_DIV_2	0x0006
++	#define AQ_SERDES_MODE_XFI		0x0000
++
++#define AQ_GLB_ING_PAUSE_CTRL_REG	0x7148
++#define AQ_GLB_EGR_PAUSE_CTRL_REG	0x4148
++
++#define AQ_USB_PHY_SET_TIMEOUT		10000
++#define AQ_USB_SET_TIMEOUT		4000
++
++#define AQ_THERMAL_TIMER_MS		500
++/* Temperature thresholds in units degree of Celsius */
++#define AQ_NORMAL_TEMP_THRESHOLD	85
++#define AQ_HIGH_TEMP_THRESHOLD		106
++#define AQ_CRITICAL_TEMP_THRESHOLD	108
++
++#define AQ_SW_CONFIG_MAGIC_KEY		0xABBA
++#define AQ_SW_CONFIG_LAN		0x0001
++/* Feature. ********************************************/
++#define AQ_SUPPORT_FEATURE	(NETIF_F_SG | NETIF_F_IP_CSUM |\
++				 NETIF_F_IPV6_CSUM | NETIF_F_RXCSUM |\
++				 NETIF_F_TSO | NETIF_F_HW_VLAN_CTAG_TX |\
++				 NETIF_F_HW_VLAN_CTAG_RX)
++
++#define AQ_SUPPORT_HW_FEATURE	(NETIF_F_SG | NETIF_F_IP_CSUM |\
++				 NETIF_F_IPV6_CSUM | NETIF_F_RXCSUM |\
++				 NETIF_F_TSO | NETIF_F_HW_VLAN_CTAG_FILTER)
++
++#define AQ_SUPPORT_VLAN_FEATURE (NETIF_F_SG | NETIF_F_IP_CSUM |\
++				 NETIF_F_IPV6_CSUM | NETIF_F_RXCSUM |\
++				 NETIF_F_TSO)
++
++/* DC Reg. *********************************************/
++#define DC_SS_CTL			0x310
++
++/* SFR Reg. ********************************************/
++
++#define SFR_GENERAL_STATUS		0x03
++#define SFR_CHIP_STATUS			0x05
++#define SFR_RX_CTL			0x0B
++	#define SFR_RX_CTL_TXPADCRC		0x0400
++	#define SFR_RX_CTL_IPE			0x0200
++	#define SFR_RX_CTL_DROPCRCERR		0x0100
++	#define SFR_RX_CTL_START		0x0080
++	#define SFR_RX_CTL_RF_WAK		0x0040
++	#define SFR_RX_CTL_AP			0x0020
++	#define SFR_RX_CTL_AM			0x0010
++	#define SFR_RX_CTL_AB			0x0008
++	#define SFR_RX_CTL_AMALL		0x0002
++	#define SFR_RX_CTL_PRO			0x0001
++	#define SFR_RX_CTL_STOP			0x0000
++#define SFR_INTER_PACKET_GAP_0		0x0D
++#define SFR_NODE_ID			0x10
++#define SFR_MULTI_FILTER_ARRY		0x16
++#define SFR_MEDIUM_STATUS_MODE		0x22
++	#define SFR_MEDIUM_XGMIIMODE		0x0001
++	#define SFR_MEDIUM_FULL_DUPLEX		0x0002
++	#define SFR_MEDIUM_RXFLOW_CTRLEN	0x0010
++	#define SFR_MEDIUM_TXFLOW_CTRLEN	0x0020
++	#define SFR_MEDIUM_JUMBO_EN		0x0040
++	#define SFR_MEDIUM_RECEIVE_EN		0x0100
++#define SFR_MONITOR_MODE		0x24
++	#define SFR_MONITOR_MODE_EPHYRW		0x01
++	#define SFR_MONITOR_MODE_RWLC		0x02
++	#define SFR_MONITOR_MODE_RWMP		0x04
++	#define SFR_MONITOR_MODE_RWWF		0x08
++	#define SFR_MONITOR_MODE_RW_FLAG	0x10
++	#define SFR_MONITOR_MODE_PMEPOL		0x20
++	#define SFR_MONITOR_MODE_PMETYPE	0x40
++#define SFR_PHYPWR_RSTCTL		0x26
++	#define SFR_PHYPWR_RSTCTL_BZ		0x0010
++	#define SFR_PHYPWR_RSTCTL_IPRL		0x0020
++#define SFR_VLAN_ID_ADDRESS		0x2A
++#define SFR_VLAN_ID_CONTROL		0x2B
++	#define SFR_VLAN_CONTROL_WE		0x0001
++	#define SFR_VLAN_CONTROL_RD		0x0002
++	#define SFR_VLAN_CONTROL_VSO		0x0010
++	#define SFR_VLAN_CONTROL_VFE		0x0020
++#define SFR_VLAN_ID_DATA0		0x2C
++#define SFR_VLAN_ID_DATA1		0x2D
++#define SFR_RX_BULKIN_QCTRL		0x2E
++	#define SFR_RX_BULKIN_QCTRL_TIME	0x01
++	#define SFR_RX_BULKIN_QCTRL_IFG		0x02
++	#define SFR_RX_BULKIN_QCTRL_SIZE	0x04
++#define SFR_RX_BULKIN_QTIMR_LOW		0x2F
++#define SFR_RX_BULKIN_QTIMR_HIGH	0x30
++#define SFR_RX_BULKIN_QSIZE		0x31
++#define SFR_RX_BULKIN_QIFG		0x32
++#define SFR_RXCOE_CTL			0x34
++	#define SFR_RXCOE_IP			0x01
++	#define SFR_RXCOE_TCP			0x02
++	#define SFR_RXCOE_UDP			0x04
++	#define SFR_RXCOE_ICMP			0x08
++	#define SFR_RXCOE_IGMP			0x10
++	#define SFR_RXCOE_TCPV6			0x20
++	#define SFR_RXCOE_UDPV6			0x40
++	#define SFR_RXCOE_ICMV6			0x80
++#define SFR_TXCOE_CTL			0x35
++	#define SFR_TXCOE_IP			0x01
++	#define SFR_TXCOE_TCP			0x02
++	#define SFR_TXCOE_UDP			0x04
++	#define SFR_TXCOE_ICMP			0x08
++	#define SFR_TXCOE_IGMP			0x10
++	#define SFR_TXCOE_TCPV6			0x20
++	#define SFR_TXCOE_UDPV6			0x40
++	#define SFR_TXCOE_ICMV6			0x80
++#define SFR_BM_INT_MASK			0x41
++#define SFR_BMRX_DMA_CONTROL		0x43
++	#define SFR_BMRX_DMA_EN			0x80
++#define SFR_BMTX_DMA_CONTROL		0x46
++#define SFR_PAUSE_WATERLVL_LOW		0x54
++#define SFR_PAUSE_WATERLVL_HIGH		0x55
++#define SFR_ARC_CTRL			0x9E
++#define SFR_SWP_CTRL			0xB1
++#define SFR_TX_PAUSE_RESEND_T		0xB2
++#define SFR_ETH_MAC_PATH		0xB7
++	#define SFR_RX_PATH_READY		0x01
++#define SFR_BULK_OUT_CTRL		0xB9
++	#define SFR_BULK_OUT_FLUSH_EN		0x01
++	#define SFR_BULK_OUT_EFF_EN		0x02
++
++#define AQ_FW_VER_MAJOR			0xDA
++#define AQ_FW_VER_MINOR			0xDB
++#define AQ_FW_VER_REV			0xDC
++
++#define AQ_PRIV_FLAGS_MASK		0x3
++#define AQ_PF_XFI_DIV_2			BIT(0)
++#define AQ_PF_THERMAL			BIT(1)
++
++/*PHY_OPS**********************************************************************/
++
++#define AQ_ADV_100M	BIT(0)
++#define AQ_ADV_1G	BIT(1)
++#define AQ_ADV_2G5	BIT(2)
++#define AQ_ADV_5G	BIT(3)
++#define AQ_ADV_MASK	0x0F
++
++#define AQ_PAUSE	BIT(16)
++#define AQ_ASYM_PAUSE	BIT(17)
++#define AQ_LOW_POWER	BIT(18)
++#define AQ_PHY_POWER_EN	BIT(19)
++#define AQ_WOL		BIT(20)
++#define AQ_DOWNSHIFT	BIT(21)
++#define AQ_XFI_DIV_2	BIT(22)
++
++#define AQ_DSH_RETRIES_SHIFT	0x18
++#define AQ_DSH_RETRIES_MASK	0xF000000
++
++#define AQ_WOL_FLAG_MP			0x2
++
++/******************************************************************************/
++
++struct aqc111_wol_cfg {
++	u8 hw_addr[6];
++	u8 flags;
++	u8 rsvd[283];
++} __packed;
++
++struct aqc111_thermal_params {
++	u8 enable;
++	u8 threshold_critical;
++	u8 threshold_high;
++	u8 threshold_normal;
++	u8 phy_speed_mask;
++} __packed;
++
++#define WOL_CFG_SIZE sizeof(struct aqc111_wol_cfg)
++
++struct aqc111_data {
++	u16 rxctl;
++	u8 rx_checksum;
++	u8 link_speed;
++	u8 link;
++	u8 autoneg;
++	u32 advertised_speed;
++	struct {
++		u8 major;
++		u8 minor;
++		u8 rev;
++	} fw_ver;
++	u8 dpa; /*direct PHY access*/
++	u32 phy_cfg;
++	u8 wol_flags;
++	u32 priv_flags;
++};
++
++#define AQ_LS_MASK		0x8000
++#define AQ_SPEED_MASK		0x7F00
++#define AQ_SPEED_SHIFT		0x0008
++#define AQ_INT_SPEED_5G		0x000F
++#define AQ_INT_SPEED_2_5G	0x0010
++#define AQ_INT_SPEED_1G		0x0011
++#define AQ_INT_SPEED_100M	0x0013
++
++/* TX Descriptor */
++#define AQ_TX_DESC_LEN_MASK	0x1FFFFF
++#define AQ_TX_DESC_DROP_PADD	BIT(28)
++#define AQ_TX_DESC_VLAN		BIT(29)
++#define AQ_TX_DESC_MSS_MASK	0x7FFF
++#define AQ_TX_DESC_MSS_SHIFT	0x20
++#define AQ_TX_DESC_VLAN_MASK	0xFFFF
++#define AQ_TX_DESC_VLAN_SHIFT	0x30
++
++#define AQ_RX_HW_PAD			0x02
++
++/* RX Packet Descriptor */
++#define AQ_RX_PD_L4_ERR		BIT(0)
++#define AQ_RX_PD_L3_ERR		BIT(1)
++#define AQ_RX_PD_L4_TYPE_MASK	0x1C
++#define AQ_RX_PD_L4_UDP		0x04
++#define AQ_RX_PD_L4_TCP		0x10
++#define AQ_RX_PD_L3_TYPE_MASK	0x60
++#define AQ_RX_PD_L3_IP		0x20
++#define AQ_RX_PD_L3_IP6		0x40
++
++#define AQ_RX_PD_VLAN		BIT(10)
++#define AQ_RX_PD_RX_OK		BIT(11)
++#define AQ_RX_PD_DROP		BIT(31)
++#define AQ_RX_PD_LEN_MASK	0x7FFF0000
++#define AQ_RX_PD_LEN_SHIFT	0x10
++#define AQ_RX_PD_VLAN_SHIFT	0x20
++
++/* RX Descriptor header */
++#define AQ_RX_DH_PKT_CNT_MASK		0x1FFF
++#define AQ_RX_DH_DESC_OFFSET_MASK	0xFFFFE000
++#define AQ_RX_DH_DESC_OFFSET_SHIFT	0x0D
++
++static struct {
++	unsigned char ctrl;
++	unsigned char timer_l;
++	unsigned char timer_h;
++	unsigned char size;
++	unsigned char ifg;
++} AQC111_BULKIN_SIZE[] = {
++	/* xHCI & EHCI & OHCI */
++	{7, 0x00, 0x01, 0x1E, 0xFF},/* 10G, 5G, 2.5G, 1G */
++	{7, 0xA0, 0x00, 0x14, 0x00},/* 100M */
++	/* Jumbo packet */
++	{7, 0x00, 0x01, 0x18, 0xFF},
++};
++
++#endif /* __LINUX_USBNET_AQC111_H */

--- a/SOURCES/aqc111u-1.3.3.0.tar.gz
+++ b/SOURCES/aqc111u-1.3.3.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0075d3e0cd140e2f3af620d459022887a561816a293301c2687f4ddbedc867d8
+size 16316

--- a/SPECS/aqc111u-module.spec
+++ b/SPECS/aqc111u-module.spec
@@ -1,0 +1,63 @@
+%define vendor_name Marvell
+%define vendor_label marvell
+%define driver_name aqc111u
+
+%if %undefined module_dir
+%define module_dir extra
+%endif
+
+Summary: %{vendor_name} %{driver_name} device drivers
+Name: %{driver_name}-module
+Version: 1.3.3.0
+Release: 1%{?dist}
+License: GPL
+
+#Source taken from https://www.marvell.com/content/dam/marvell/en/drivers/AQ_USBDongle_LinuxDriver_1.3.3.0.zip
+Source0: %{driver_name}-%{version}.tar.gz
+
+Patch0: %{driver_name}-%{version}.patch
+
+BuildRequires: gcc
+BuildRequires: kernel-devel
+Provides: %{driver_name}-module
+Requires: kernel-uname-r = %{kernel_version}
+Requires(post): /usr/sbin/depmod
+Requires(postun): /usr/sbin/depmod
+
+%description
+%{vendor_name} %{driver_name} device drivers for the Linux Kernel
+version %{kernel_version}.
+
+%prep
+%autosetup -n %{driver_name}-%{version}
+
+%build
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd) KSRC=/lib/modules/%{kernel_version}/build modules
+
+%install
+%{__make} %{?_smp_mflags} -C /lib/modules/%{kernel_version}/build M=$(pwd) INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
+
+# remove extra files modules_install copies in
+rm -f %{buildroot}/lib/modules/%{kernel_version}/modules.*
+
+# mark modules executable so that strip-to-file can strip them
+find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chmod u+x
+
+%post
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_post}
+
+%postun
+/sbin/depmod %{kernel_version}
+%{regenerate_initrd_postun}
+
+%posttrans
+%{regenerate_initrd_posttrans}
+
+%files
+/lib/modules/%{kernel_version}/*/*.ko
+
+%changelog
+* Sun May 09 2021 Simone Conti <s.conti@itnok.com> - 1.3.3.0-1
+- Adding patch to rename kernel module from `aqc111` to `aqc111u`
+- Re-packing for XCP-ng of Marvell AQC111U driver


### PR DESCRIPTION
Thanks @stormi for providing the dummy LFS file to allow the push in my fork.

Hopefully, this PR satisfies your standards, if not please feel free to point out what I need to correct to comply.

As you might have noticed I changed the name of the repo to aqc111u-module _(added the `u` part)_ this, might not fully adhere to your policy as the final kernel module produced it is still called `aqc111`, but it is IMHO a better naming strategy considering that an `aqc111` driver does exist and, despite addressing the same chipset, does not work for NICs using USB3 at transport layer _(it's for the regular PCIe NICs)_. The `u` in the driver name stands for USB and is the only differentiating aspect between `aqc111` and `aqc111u`.

Two possible approaches if you do not like having the name of the repo changed while the produced module is still `aqc111`:

- Altering the code provided by Marvell _(is GPL and as long as all authors are mentioned is fine I believe)_ to produce a `aqc111u` kmodule instead;
- Keep the name as `aqc111-module` for the repo _(this driver is already in the Linux Kernel upstream since 5.12-rc6 supporting the `aqc111u` not to be confused with the Aquantia Atlantic which supports `aqc111`, `aqc200` and others)_

Poor naming convention choices if you ask me... but nevertheless that's what we currently have.

Other than that, you will see a much _"puffier"_ README.md _(not sure it that's allowed)_ and the fact that instead of pulling the drivers directly from the website _(of Sabrent originally or Marvell, even better)_ the source code has been added to the repo directly, hence the LFS problem)_

Thanks